### PR TITLE
:bug: Make it so the new default source logic works on the ID results page

### DIFF
--- a/layouts/header.tsx
+++ b/layouts/header.tsx
@@ -70,8 +70,12 @@ const Header = (): JSX.Element => {
                             </Button>
                         </Form>
                         <OverlayTrigger placement="bottom" overlay={<Tooltip id="glossary">Glossary</Tooltip>}>
-                            <Nav.Link className="ml-auto" href="/glossary">
-                                ?
+                            <Nav.Link
+                                style={{ height: 38, width: 38 }}
+                                className="border border-success rounded m-1 text-center"
+                                href="/glossary"
+                            >
+                                <span className="text-success">?</span>
                             </Nav.Link>
                         </OverlayTrigger>
                     </Nav>

--- a/libs/db/gall.ts
+++ b/libs/db/gall.ts
@@ -17,6 +17,7 @@ import {
     WallsApi,
 } from '../api/apitypes';
 import { deleteImagesBySpeciesId } from '../images/images';
+import { defaultSource } from '../pages/renderhelpers';
 import { logger } from '../utils/logger';
 import { ExtractTFromPromise } from '../utils/types';
 import { handleError, optionalWith } from '../utils/util';
@@ -81,7 +82,7 @@ export const getGalls = (
                 return []; // will resolve to nothing since we are in a flatMap
             }
             // set the default description to make the caller's life easier
-            const d = g.speciessource.find((s) => s.useasdefault === 1)?.description;
+            const d = defaultSource(g.speciessource)?.description;
 
             const newg: GallApi = {
                 ...g,

--- a/libs/pages/renderhelpers.tsx
+++ b/libs/pages/renderhelpers.tsx
@@ -41,17 +41,16 @@ export const renderParagraph = (p: string): React.ReactNode => {
  * are not sources marked as default, then the source with the oldest publication year will be used.
  * @param species
  */
-export const defaultSource = (species: GallApi): SpeciesSourceApi | undefined => {
-    if (species && species.speciessource.length > 1) {
+export const defaultSource = <T extends { useasdefault: number; source: { pubyear: string } }>(
+    speciessource: T[],
+): T | undefined => {
+    if (speciessource && speciessource.length > 1) {
         // if there is one marked as default, use that
-        const source = species.speciessource.find((s) => s.useasdefault !== 0);
+        const source = speciessource.find((s) => s.useasdefault !== 0);
         if (source) return source;
 
         // otherwise pick the one that has the oldest publication date
-        return species.speciessource.reduce(
-            (acc, v) => (acc && acc.source.pubyear < v.source.pubyear ? acc : v),
-            species.speciessource[0],
-        );
+        return speciessource.reduce((acc, v) => (acc && acc.source.pubyear < v.source.pubyear ? acc : v), speciessource[0]);
     } else {
         return undefined;
     }

--- a/pages/gall/[id]/index.tsx
+++ b/pages/gall/[id]/index.tsx
@@ -57,8 +57,7 @@ const hostAsLink = (len: number) => (h: GallHost, idx: number) => {
 };
 
 const Gall = ({ species, imagePaths }: Props): JSX.Element => {
-    const source = defaultSource(species);
-    const [selectedSource, setSelectedSource] = useState(source);
+    const [selectedSource, setSelectedSource] = useState(defaultSource(species?.speciessource));
     const [sourceList, setSourceList] = useState({ data: species?.speciessource, sortIndex: 0, sortOrder: -1 });
     const [images, setImages] = useState(imagePaths);
 


### PR DESCRIPTION
Also tweaked the glossary link in the header to hopefully make it more noticable.