### PR TITLE
Two help pages, updated header nav menu, id page notes/tips

### DIFF
--- a/layouts/header.tsx
+++ b/layouts/header.tsx
@@ -1,7 +1,8 @@
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { KeyboardEvent, SyntheticEvent, useState } from 'react';
-import { Button, Form, FormControl, Nav, Navbar, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Button, Dropdown, Form, FormControl, Nav, Navbar, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 const Header = (): JSX.Element => {
     const [searchText, setSearchText] = useState('');
@@ -69,15 +70,20 @@ const Header = (): JSX.Element => {
                                 Search
                             </Button>
                         </Form>
-                        <OverlayTrigger placement="bottom" overlay={<Tooltip id="glossary">Glossary</Tooltip>}>
-                            <Nav.Link
-                                style={{ height: 38, width: 38 }}
-                                className="border border-success rounded m-1 text-center"
-                                href="/glossary"
+                        <Dropdown>
+                            <Dropdown.Toggle
+                                className="border border-success rounded m-1"
+                                id="resources-button"
+                                variant="outline-success"
                             >
-                                <span className="text-success">?</span>
-                            </Nav.Link>
-                        </OverlayTrigger>
+                                Resources
+                            </Dropdown.Toggle>
+                            <Dropdown.Menu align="right">
+                                <Dropdown.Item href="/guide">ID Guide</Dropdown.Item>
+                                <Dropdown.Item href="/filterguide">Filter Terms</Dropdown.Item>
+                                <Dropdown.Item href="/glossary">Plant and Insect Glossary</Dropdown.Item>
+                            </Dropdown.Menu>
+                        </Dropdown>
                     </Nav>
                 </Navbar.Collapse>
             </Navbar>

--- a/pages/filterguide.tsx
+++ b/pages/filterguide.tsx
@@ -1,0 +1,224 @@
+import Head from 'next/head';
+import React from 'react';
+import Link from 'next/link';
+import { ListGroup, Container, Accordion, Card, Button } from 'react-bootstrap';
+
+const { Item } = ListGroup;
+
+export default function FilterGuide(): JSX.Element {
+  return (
+    <React.Fragment>
+      <Head>
+        <title>Filter Guide</title>
+      </Head>
+      <Container fluid className="ml-2">
+        <h1>ID Tool Filter Guide</h1>
+        <br/>
+        <Accordion>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="0">
+                Location
+              </Accordion.Toggle>
+            </Card.Header>
+            <Accordion.Collapse eventKey="0">
+              <ListGroup>
+                <Item key="at leaf vein angles">
+                  <b>At leaf vein angles -</b> galls located exclusively in
+                  the inside of the intersection between the lateral veins and
+                  main veins of the leaf.
+                </Item>
+                <Item key="between leaf veins">
+                  <b>Between leaf veins -</b> galls are not specifically
+                  located only on leaf veins. Galls with this term may sometimes
+                  incidentally appear close to veins.
+                </Item>
+                <Item key="bud">
+                  <b>Bud -</b> galls are located in buds (often found where
+                  branches intersect the stem, can be mistaken for stem galls).
+                </Item>
+                <Item key="flower">
+                  <b>Flower -</b> galls are located in flowers. Note this is a
+                  botanical term referring to reproductive structures, and some
+                  flowers (eg oak catkins) may not be obviously recognizable as such.
+                </Item>
+                <Item key="fruit">
+                  <b>Fruit -</b> galls are located in fruit. This is a botanical
+                  term referring to seed-bearing structures, and some fruit (eg
+                  maple samaras) may not be obviously recognizable as such.
+                </Item>
+                <Item key="leaf midrib">
+                  <b>Leaf midrib -</b> galls are located exclusively on the
+                  thickest, central vein of the leaf.
+                </Item>
+                <Item key="lower leaf">
+                  <b>Lower leaf -</b> galls are located on the lower (abaxial) side
+                  of the leaf.
+                </Item>
+                <Item key="on leaf veins">
+                  <b>On leaf veins -</b> galls are located exclusively on or very
+                  close to the veins of the leaf, including but not limited to the
+                  midrib.
+                </Item>
+                <Item key="petiole">
+                  <b>Petiole -</b> galls are located on the part of the midrib
+                  between the leaf and the stem.
+                </Item>
+                <Item key="root">
+                  <b>Root -</b> galls are located on the roots of the plant or
+                  near the base of the stem.
+                </Item>
+                <Item key="stem">
+                  <b>Stem -</b> galls are located anywhere in or on the stem
+                  (except within buds, which are occasionally deformed by gall
+                  inducers enough to appear as stem galls).
+                </Item>
+                <Item key="upper leaf">
+                  <b>Upper leaf -</b> galls are located on the upper (adaxial)
+                  side of the leaf.
+                </Item>
+                <Item key="leaf edge">
+                  <b>Leaf edge -</b> galls are exclusively located around the edge
+                  of the leaf, often curled or folded.
+                </Item>
+              </ListGroup>
+            </Accordion.Collapse>
+          </Card>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="1">
+                Detachable
+              </Accordion.Toggle>
+            </Card.Header>
+          </Card>
+          <Accordion.Collapse eventKey="1">
+            <ListGroup>
+              <Item key="yes">
+                <b>Yes -</b> the gall could be removed from the plant without
+                destroying the tissue it’s attached to (detachable).
+              </Item>
+              <Item key="no">
+                <b>No -</b> the gall could only be removed from the plant by
+                destroying the tissue it’s attached to (integral).
+              </Item>
+              <Item key="note">
+                NOTE: Galls that have detachable parts but leave some galled
+                tissue behind (more than a scar or blister), are only detachable
+                in some parts of the season, or may be detachable or not, are
+                included in both terms.
+              </Item>
+            </ListGroup>
+          </Accordion.Collapse>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="2">
+                Texture
+              </Accordion.Toggle>
+            </Card.Header>
+          </Card>
+          <Accordion.Collapse eventKey="2">
+            <ListGroup>
+              <Item key="hairy">
+                <b>Hairy -</b> the gall has some hairs, whether that's only a sparse
+                pubescence of short hairs or a dense coat of long wool that obscures
+                the gall or stiff bristles (as in Acraspis erinacei).
+              </Item>
+              <Item key="hairless">
+                <b>Hairless -</b> the gall has no visible hairs at all. Note that
+                late in hte season, hairs may wear off some galls.
+              </Item>
+              <Item key="erineum">
+                <b>Erineum -</b> the distinctive "sugary" crystalline texture
+                formed by many eriophyid mites.
+              </Item>
+              <Item key="sticky">
+                <b>Sticky -</b> the gall exudes some kind of sticky fluid. In some 
+                cases this fluid is attractive to ants and is often visible as a wet
+                sheen in photos, but ideally it should be tested by touch in the field.
+              </Item>
+            </ListGroup>
+          </Accordion.Collapse>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="3">
+                Alignment
+              </Accordion.Toggle>
+            </Card.Header>
+          </Card>
+          <Accordion.Collapse eventKey="3">
+            <ListGroup>
+              <Item key="leaning">
+                <b>Leaning -</b> the gall is at an angle from the surface it is
+                attached to.
+              </Item>
+              <Item key="erect">
+                <b>Erect -</b> the gall stands at nearly 90 degrees from the surface
+                it is attached to. Includes the majority of detachable galls.
+              </Item>
+              <Item key="integral">
+                <b>Integral -</b> the gall is integral with the surface it is
+                attached to. It may not be flat, but it doesn't protrude out
+                from the surface leaving an angled gap. Includes nearly all
+                non-detachable galls.
+              </Item>
+              <Item key="supine">
+                <b>Supine -</b> the gall is only attached at its base but lays nearly
+                flat along the surface it is attached to for most of its length.
+              </Item>
+            </ListGroup>
+          </Accordion.Collapse>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="4">
+                Walls
+              </Accordion.Toggle>
+            </Card.Header>
+          </Card>
+          <Accordion.Collapse eventKey="4">
+            <ListGroup>
+              <Item key="thin">
+                <b>Thin -</b> when the gall is cut open, it reveals an interior
+                matching the shape of the exterior. The walls are not thick enough
+                to conceal the shape of the chamber within.
+              </Item>
+              <Item key="thick">
+                <b>Thick -</b> when the gall is cut open, the interior is full of
+                tissue except for the small chamber containing the larvae. The walls
+                are thick enough that the shape of this chamber could (but may not
+                necessarily) differ from the shape of the exterior.
+              </Item>
+              <Item key="false-chamber">
+                <b>False chamber -</b> when the gall is cut open, there are two
+                chambers, only one of which contains larvae.
+              </Item>
+            </ListGroup>
+          </Accordion.Collapse>
+          <Card>
+            <Card.Header>
+              <Accordion.Toggle as={Button} variant="light" eventKey="5">
+                Cells
+              </Accordion.Toggle>
+            </Card.Header>
+          </Card>
+          <Accordion.Collapse eventKey="5">
+            <ListGroup>
+              <Item key="single">
+                <b>Single -</b> the gall's structure is built to accomodate only a
+                single space for a gall-inducer larva, pupa, or adult. 
+              </Item>
+              <Item key="multiple">
+                <b>Multiple -</b> the gall's structure is built to accomodate spaces
+                for multiple gall-inducer larvae, pupae, or adults.
+              </Item>
+              <Item>
+                NOTE: If multiple larvae are found in one space, these may
+                be <Link href="/glossary#inquiline">inquilines</Link> rather than
+                gall-inducers.
+              </Item>
+            </ListGroup>
+          </Accordion.Collapse>
+        </Accordion>
+      </Container>
+    </React.Fragment>
+  );
+}

--- a/pages/guide.tsx
+++ b/pages/guide.tsx
@@ -1,0 +1,142 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import React from 'react';
+import { Container } from 'react-bootstrap';
+
+export default function Guide(): JSX.Element {
+  return (
+    <React.Fragment>
+      <Head>
+        <title>Guide</title>
+      </Head>
+      <Container>
+        <h1>Introduction to Gall ID</h1>
+        <br/>
+        <p>
+          A <Link href="/glossary#gall">gall</Link> is a novel organ grown by a
+          plant when another organism alters the way the plant expresses its genes.
+          Gall-inducers are found in a wide range of taxa. Insects, mites, and
+          fungi are the most common, but nematodes, bacteria, and even plants
+          can also induce galls.
+        </p>
+        <p>
+          Because gall induction is a biochemical alteration of the growth pattern
+          of a plant, galls are highly targeted, usually specific to a single
+          part of one or several closely related <Link href="/glossary#host">host</Link> species.
+          Some gall-inducing species form distinct galls on different
+          hosts or, in different portions of their lifecycle, on different parts
+          of the same host. These galls are listed separately in the database.
+        </p>
+        <p>
+          Galls typically have unique, recognizable exterior features that are
+          distinct from galls formed by their close relatives. This means that
+          identifying a gall-inducer to species requires no taxon-specific
+          anatomical knowledge and is generally much easier than identifying other
+          fungi or arthropods.
+        </p>
+        <p>
+          Galls are created to feed and protect their inducers, and these
+          conditions are attractive to other organisms. Many galls are targeted
+          by predators, parasitoids, and <Link href="/glossary#inquiline">inquilines</Link> that
+          live within the gall, some of which do not harm the gall-inducer.
+          In most cases this database does not include these organisms, but a
+          few inquilines modify developing galls and create distinct galls, and
+          in these cases the gall is listed as a separate entry in the database.
+        </p>
+        <h3 className="mb-3">Using our ID tool</h3>
+        <p>
+          The most important step in gall ID is the correct identification of the
+          host plant. If you’re not sure what your plant is, you can take a photo
+          and make an observation on iNaturalist. The site’s computer vision
+          algorithm will give you a plausible suggestion, which you can confirm
+          yourself with other resources and will likely be confirmed or corrected
+          by other users. There are many plant ID resources available online:
+        </p>
+        <ul>
+          <li><Link href="https://gobotany.nativeplanttrust.org/advanced/">New England</Link></li>
+          <li><Link href="https://michiganflora.net/">Michigan</Link></li>
+          <li><Link href="efloras.org/flora_page.aspx?flora_id=1">North America</Link></li>
+          <li><Link href="http://tchester.org/plants/analysis/salix/key.html#picture">California (willows only)</Link></li>
+        </ul>
+        <p>
+          For plants with few galls, host ID alone will likely filter the
+          possibilities enough that your gall is recognizable. However, most galls
+          are found on plant species with many galls. In those cases, select
+          additional traits, starting with location and detachable, until the
+          results are manageable. See the gall <Link href="/filterguide">filter term guide</Link> for
+          more info on what these selections mean.
+        </p>
+        <p>
+          Once you find a plausible set of options, you may want to confirm your
+          ID by checking the original descriptions of the gall, available on its
+          page. Additional information about taxonomic shifts and ID tips is also
+          available on each gall page.
+        </p>
+        <p>
+          Be aware that this database is a work in progress and many galls may
+          not be added yet. The database is complete for plants and galls marked as such.
+          However, many gall-inducing species are not yet described, and if you
+          find a gall that is not listed on a host that is marked complete,
+          please contact us at gallformers@gmail.com.
+        </p>
+        <h3 className="mb-3" id="troubleshooting">ID tips and troubleshooting</h3>
+        <p>
+          If you’re not finding a match, try using only host, location, and
+          detachable before you give up. Common issues using these filters include
+        </p>
+        <ul>
+          <li>
+            wrong host ID (try moving up to the genus level or checking your
+            second or third guesses)
+          </li>
+          <li>
+            Host not included in the database. Many hybrids or rare species,
+            especially among highly speciose host groups like oaks or goldenrods,
+            may not appear in the database at all or may not have comprehensive
+            gall associations. Try searching a close relative or hybrid parent
+            instead, or the section for Quercus or Carya.
+          </li>
+          <li>
+            Whether a gall is “Between veins” or “on leaf veins” can occasionally
+            be ambiguous or misleading; try choosing the opposite or avoiding
+            these terms entirely
+          </li>
+          <li>Bud galls are often mistaken for stem galls</li>
+          <li>
+            Acorn galls on red oaks can be mistaken for bud galls (red-group oaks
+            have small overwintering acorns with similar size and placement as their buds)
+          </li>
+          <li>
+            A gall looks detachable but is not (or vice versa); check the
+            results for the opposite option
+          </li>
+          <li>
+            If your gall is only found on the leaf midrib, it may be a species
+            that could theoretically be found on any of the leaf veins; check
+            “on leaf veins” instead
+          </li>
+          <li>
+            Gall-inducers, especially cynipid wasps, occasionally form galls on
+            the opposite side of the leaf from their normal habit; check the
+            results for the opposite option 
+          </li>
+        </ul>
+        <p>
+          Generally speaking, it’s a good idea to try sequentially removing
+          filters to make sure you’re not missing relevant possibilities.
+        </p>
+        <p>
+          Other traits, including color, walls, cells, alignment, shape, and
+          texture, may not be added comprehensively or at all. Check the
+          gall <Link href="/filterguide">filter term guide</Link> to make sure you’re
+          applying the terms consistently with our usage.
+        </p>
+        <p>
+          Note that if you search by host at the section or genus level, you
+          are likely to encounter galls from other parts of the country than
+          your observation. Be sure to confirm the range makes sense before making an ID.
+        </p>
+      </Container>
+    </React.Fragment>
+  );
+}

--- a/pages/id.tsx
+++ b/pages/id.tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
 import React, { useState } from 'react';
-import { Col, ListGroup, Row } from 'react-bootstrap';
+import { Alert, Col, ListGroup, Row } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import InfoTip from '../components/infotip';
@@ -200,8 +200,21 @@ const IDGall = (props: Props): JSX.Element => {
             <form onSubmit={handleSubmit(onSubmit)} className="fixed-left mt-2 ml-4 mr-2 form-group">
                 <Row>
                     <Col>
+                        <Alert variant="warning" className="ml-5 mr-5">
+                            Note: our database is a work in progress. Except where indicated otherwise, the ID results
+                            for any given host should not be considered comprehensive, and the traits, host relationships,
+                            and source entries for any gall inducer that does appear in the database may be incomplete.
+                        </Alert>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
                         First select either the host species or the genus/section for a host if you are unsure of the species,
                         then press Search. You can then filter the found galls using the boxes on the left.
+                        See the <Link href="/filterguide">Gall Filter Term Guide</Link> if you’re
+                        uncertain about our usage of the terms in the filters. Note that leaving a field blank doesn’t
+                        exclude any galls, whether they have values in that field or not.
+                        Choosing one or more values in a field removes all galls that don’t include at least those values.
                     </Col>
                 </Row>
                 <Row>
@@ -362,29 +375,40 @@ const IDGall = (props: Props): JSX.Element => {
                                         on the left to narrow down the list.
                                     </h4>
                                 ) : (
-                                    <h4 className="font-weight-lighter">There are no galls that match your filter.</h4>
+                                    <h4 className="font-weight-lighter">
+                                        There are no galls that match your filter. It’s possible there are no
+                                        described species that fit this set of traits and your gall is undescribed.
+                                        However, before giving up, try <Link href="/guide#troubleshooting">altering your filter choices.</Link>
+                                    </h4>
                                 )
                             ) : (
-                                filtered.map((g) => (
-                                    <ListGroup.Item key={g.id}>
-                                        <Row key={g.id}>
-                                            <Col xs={2} className="">
-                                                <img
-                                                    src={defaultImage(g)?.small}
-                                                    width="75px"
-                                                    height="75px"
-                                                    className="img-responsive"
-                                                />
-                                            </Col>
-                                            <Col className="pl-0 pull-right">
-                                                <Link href={`gall/${g.id}`}>
-                                                    <a>{g.name}</a>
-                                                </Link>
-                                                - {truncateOptionString(g.description)}
-                                            </Col>
-                                        </Row>
-                                    </ListGroup.Item>
-                                ))
+                                <React.Fragment>
+                                    <Alert variant="info">
+                                        If none of these results match your gall, you may have found an undescribed species. However,
+                                        before concluding that your gall is not in the database,
+                                        try <Link href="/guide#troubleshooting">altering your filter choices.</Link>
+                                    </Alert>
+                                    {filtered.map((g) => (
+                                        <ListGroup.Item key={g.id}>
+                                            <Row key={g.id}>
+                                                <Col xs={2} className="">
+                                                    <img
+                                                        src={defaultImage(g)?.small}
+                                                        width="75px"
+                                                        height="75px"
+                                                        className="img-responsive"
+                                                    />
+                                                </Col>
+                                                <Col className="pl-0 pull-right">
+                                                    <Link href={`gall/${g.id}`}>
+                                                        <a>{g.name}</a>
+                                                    </Link>
+                                                    - {truncateOptionString(g.description)}
+                                                </Col>
+                                            </Row>
+                                        </ListGroup.Item>
+                                    ))}
+                                </React.Fragment>
                             )}
                         </ListGroup>
                     </Row>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,6 +45,20 @@ export default function Home(): JSX.Element {
                     <Col>
                         <Card>
                             <Card.Body>
+                            <Card.Title>Resources</Card.Title>
+                                <ul>
+                                    <li><Link href="/guide">Our guide to gall identification.</Link></li>
+                                    <li><Link href="/filterguide">Detailed descriptions for our key filters.</Link></li>
+                                    <li><Link href="/glossary">Glossary for plant and insect terms.</Link></li>
+                                </ul>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                </Row>
+                <Row className="pt-4">
+                    <Col>
+                        <Card>
+                            <Card.Body>
                                 <Card.Title>Interesting Reading</Card.Title>
                                 <ul>
                                     <li>


### PR DESCRIPTION
This isn't every help page, but since nothing here touches the database, or has any requests & data interaction, figured I'd keep this a separate PR. This incorporates all the help page content from that google doc except the "non-gall faq"/non-gall structure guide, for issue #60