### PR TITLE
detect notFound condition for family & genus

### DIFF
--- a/pages/genus/[id]/index.tsx
+++ b/pages/genus/[id]/index.tsx
@@ -70,17 +70,26 @@ const Genus = ({ genus, species }: Props): JSX.Element => {
 
 // Use static so that this stuff can be built once on the server-side and then cached.
 export const getStaticProps: GetStaticProps = async (context) => {
-    const genus = await getStaticPropsWithContext(context, taxonomyEntryById, 'genus');
-
-    return {
-        props: {
-            // must add a key so that a navigation from the same route will re-render properly
-            key: genus[0].id ?? -1,
-            genus: genus,
-            species: await getStaticPropsWithContext(context, getAllSpeciesForSectionOrGenus, 'species for genus', false, true),
-        },
-        revalidate: 1,
-    };
+    try {
+        const genus = await getStaticPropsWithContext(context, taxonomyEntryById, 'genus');
+        return {
+            props: {
+                // must add a key so that a navigation from the same route will re-render properly
+                key: genus[0].id ?? -1,
+                genus: genus,
+                species: await getStaticPropsWithContext(
+                    context,
+                    getAllSpeciesForSectionOrGenus,
+                    'species for genus',
+                    false,
+                    true,
+                ),
+            },
+            revalidate: 1,
+        };
+    } catch (e) {
+        return { notFound: true };
+    }
 };
 
 export const getStaticPaths: GetStaticPaths = async () => getStaticPathsFromIds(allGenusIds);


### PR DESCRIPTION
This isn't normally a problem, because only paths which actually exist are rendered. But, if an admin deletes something, then we'll have something in cache that *should* die on revalidation. Because we didn't account for this case, the page regeneration errors, forcing nextjs to re-serve a stale cache.

Fixes #379 (or at least, the non-user error portion of it)