### PR TITLE
Potential fix for code scanning alert no. 7: Unneeded defensive code

### DIFF
--- a/libs/api/apitypes.ts
+++ b/libs/api/apitypes.ts
@@ -603,7 +603,7 @@ export const detachableFromString = (s: string): DetachableApi => {
 };
 
 export const detachableFromId = (id: null | undefined | number): DetachableApi => {
-    if (id == undefined || id == null) return DetachableNone;
+    if (id == undefined) return DetachableNone;
 
     const d = Detachables.find((d) => d.id === id);
     if (d == undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/jeffdc/gallformers/security/code-scanning/7](https://github.com/jeffdc/gallformers/security/code-scanning/7)

To fix the issue, we will remove the redundant `id == null` check from the condition on line 606. The updated condition will only check for `id == undefined`, which already handles both `undefined` and `null`. This change simplifies the code while maintaining its intended behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
