### PR TITLE
Potential fix for code scanning alert no. 11: Comparison between inconvertible types

### DIFF
--- a/libs/utils/reactserialize.ts
+++ b/libs/utils/reactserialize.ts
@@ -70,7 +70,7 @@ type Element = {
 };
 
 function deserializeElement(element: object | [] | Element, key: string | number | undefined): ReactNode {
-    if (typeof element !== 'object' || element == null || element == undefined) {
+    if (typeof element !== 'object' || element == null) {
         return element;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/jeffdc/gallformers/security/code-scanning/11](https://github.com/jeffdc/gallformers/security/code-scanning/11)

To fix the issue, we need to remove the redundant comparison `element == undefined` and ensure the logic correctly handles the possible types of `element`. Since `element` is already checked for `null` in the same condition (`element !== 'object' || element == null`), the comparison to `undefined` is unnecessary. We can safely remove `element == undefined` without altering the functionality.

Changes will be made to the condition on line 73 to eliminate the comparison with `undefined`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
