### PR TITLE
Potential fix for code scanning alert no. 12: Malformed id attribute

### DIFF
--- a/libs/utils/forms.tsx
+++ b/libs/utils/forms.tsx
@@ -34,7 +34,7 @@ export const genOptionsWithId = <T extends { id: number | string; name: string }
 
     return (
         <>
-            {includeEmpty ? <option key="none" value="" id=""></option> : undefined}
+            {includeEmpty ? <option key="none" value=""></option> : undefined}
             {opts.map((o) => {
                 return (
                     <option key={o.id} value={o.name} id={o.id.toString()}>


### PR DESCRIPTION
Potential fix for [https://github.com/jeffdc/gallformers/security/code-scanning/12](https://github.com/jeffdc/gallformers/security/code-scanning/12)

To fix the issue, the `id` attribute on line 37 should be removed entirely, as it is unnecessary for the empty `<option>` element. The `id` attribute is typically used to uniquely identify elements, and an empty `<option>` does not require identification. Removing the `id` attribute ensures compliance with the HTML5 standard and avoids potential browser inconsistencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
