### PR TITLE
Potential fix for code scanning alert no. 14: Superfluous trailing arguments

### DIFF
--- a/__tests__/pages/about.test.tsx
+++ b/__tests__/pages/about.test.tsx
@@ -164,7 +164,7 @@ describe('getStaticProps', () => {
         });
 
         // Call getStaticProps
-        const result = (await getStaticProps({})) as GetStaticPropsResult<{ stats: Stat[]; genTime: string }>;
+        const result = (await getStaticProps()) as GetStaticPropsResult<{ stats: Stat[]; genTime: string }>;
 
         // Check if the result has the correct structure
         expect(result).toHaveProperty('props');


### PR DESCRIPTION
Potential fix for [https://github.com/jeffdc/gallformers/security/code-scanning/14](https://github.com/jeffdc/gallformers/security/code-scanning/14)

To fix the issue, the superfluous argument `{}` passed to `getStaticProps` should be removed. This will ensure that the function call is clean and does not include unnecessary arguments. The change should be made on line 167 of the file `__tests__/pages/about.test.tsx`. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
