### PR TITLE
fix: resolve critical security vulnerabilities

### DIFF
--- a/libs/api/apipage.ts
+++ b/libs/api/apipage.ts
@@ -25,6 +25,7 @@ export async function apiIdEndpoint<T>(
     const session = await getServerSession(req, res, authOptions as AuthOptions);
     if (!session) {
         res.status(401).end();
+        return;
     }
 
     const invalidQueryErr: Err = {
@@ -66,6 +67,7 @@ export async function apiUpsertEndpoint<T, R>(
     const session = await getServerSession(req, res, authOptions as AuthOptions);
     if (!session) {
         res.status(401).end();
+        return;
     }
 
     const invalidQueryErr: Err = {

--- a/libs/db/gall.ts
+++ b/libs/db/gall.ts
@@ -742,8 +742,7 @@ export const deleteGall = (speciesid: number): TaskEither<Error, DeleteResult> =
     const deleteImages = () => TE.tryCatch(() => deleteImagesBySpeciesId(speciesid), handleError);
 
     // Prisma can not do cascade deletes. See: https://github.com/prisma/prisma/issues/2057
-    const sql = `DELETE FROM species WHERE id = ${speciesid}`;
-    const gallDelete = () => TE.tryCatch(() => db.$executeRaw(Prisma.sql([sql])), handleError);
+    const gallDelete = () => TE.tryCatch(() => db.$executeRaw`DELETE FROM species WHERE id = ${speciesid}`, handleError);
 
     const toDeleteResult = (count: number): DeleteResult => {
         return {

--- a/libs/db/gallhost.ts
+++ b/libs/db/gallhost.ts
@@ -7,30 +7,24 @@ import { handleError } from '../utils/util';
 import db from './db';
 import { gallByIdAsO } from './gall';
 
-const toValues = (gallid: number, hostids: number[]) => hostids.map((h) => `(NULL, ${gallid}, ${h})`).join(',');
-
 const toInsertStatement = (gallid: number, hostids: number[]): PrismaPromise<number> => {
-    const sql = `INSERT INTO host (id, gall_species_id, host_species_id) VALUES ${toValues(gallid, hostids)};`;
-    return db.$executeRaw(Prisma.sql([sql]));
+    // Build parameterized VALUES for batch insert using Prisma.join
+    const values = hostids.map((h) => Prisma.sql`(NULL, ${gallid}, ${h})`);
+    return db.$executeRaw`INSERT INTO host (id, gall_species_id, host_species_id) VALUES ${Prisma.join(values)}`;
 };
 
 export const updateGallHosts = (gallhost: GallHostUpdateFields): TE.TaskEither<Error, GallApi> => {
     const doTx = () => () => {
-        const sql = `DELETE FROM host WHERE gall_species_id = ${gallhost.gall};`;
-        const deletes = db.$executeRaw(Prisma.sql([sql]));
+        const deletes = db.$executeRaw`DELETE FROM host WHERE gall_species_id = ${gallhost.gall}`;
         const hosts = [...new Set([...gallhost.hosts])];
 
-        const steps = [deletes];
+        const steps: PrismaPromise<number>[] = [deletes];
         if (hosts.length > 0) steps.push(toInsertStatement(gallhost.gall, hosts));
 
         // handle the gall range - for now hack using the existing table
-        steps.push(db.$executeRaw(Prisma.sql([`DELETE FROM speciesplace WHERE species_id = ${gallhost.gall}`])));
+        steps.push(db.$executeRaw`DELETE FROM speciesplace WHERE species_id = ${gallhost.gall}`);
         gallhost.rangeExclusions.forEach((place) =>
-            steps.push(
-                db.$executeRaw(
-                    Prisma.sql([`INSERT INTO speciesplace (species_id, place_id) VALUES (${gallhost.gall}, ${place.id})`]),
-                ),
-            ),
+            steps.push(db.$executeRaw`INSERT INTO speciesplace (species_id, place_id) VALUES (${gallhost.gall}, ${place.id})`),
         );
 
         return db.$transaction(steps);

--- a/libs/db/place.ts
+++ b/libs/db/place.ts
@@ -110,8 +110,7 @@ export const placeById = (id: number): TaskEither<Error, PlaceWithHostsApi[]> =>
 export const deletePlace = (id: number): TaskEither<Error, DeleteResult> => {
     const results = () => {
         // since Prisma does not yet handle cascade deletion
-        const sql = `DELETE FROM place WHERE id = ${id}`;
-        return db.$executeRaw(Prisma.sql([sql]));
+        return db.$executeRaw`DELETE FROM place WHERE id = ${id}`;
     };
 
     const toDeleteResult = (result: number): DeleteResult => {

--- a/libs/db/source.ts
+++ b/libs/db/source.ts
@@ -1,4 +1,4 @@
-import { Prisma, source } from '@prisma/client';
+import { source } from '@prisma/client';
 import * as TE from 'fp-ts/lib/TaskEither';
 import { TaskEither } from 'fp-ts/lib/TaskEither';
 import { pipe } from 'fp-ts/lib/function';
@@ -122,8 +122,7 @@ export const sourcesWithSpeciesSourceBySpeciesId = (speciesId: number): TaskEith
 
 export const deleteSource = (id: number): TaskEither<Error, DeleteResult> => {
     // have to make raw call since Prisma does not handle cascade delete:  https://github.com/prisma/prisma/issues/2057
-    const sql = `DELETE FROM source WHERE id = ${id}`;
-    const doDelete = () => db.$executeRaw(Prisma.sql([sql]));
+    const doDelete = () => db.$executeRaw`DELETE FROM source WHERE id = ${id}`;
 
     const toDeleteResult = (count: number): DeleteResult => {
         return {

--- a/libs/db/species.ts
+++ b/libs/db/species.ts
@@ -9,15 +9,11 @@ import { connectIfNotNull } from './utils';
 
 export const updateAbundance = (id: number, abundance: string | undefined | null): PrismaPromise<number> => {
     if (abundance == undefined) {
-        const sql = `UPDATE species
-            SET abundance_id = NULL
-            WHERE id = ${id}`;
-        return db.$executeRaw(Prisma.sql([sql]));
+        return db.$executeRaw`UPDATE species SET abundance_id = NULL WHERE id = ${id}`;
     } else {
-        const sql = `UPDATE species 
-            SET abundance_id = (SELECT id FROM abundance WHERE abundance = '${abundance}')
+        return db.$executeRaw`UPDATE species
+            SET abundance_id = (SELECT id FROM abundance WHERE abundance = ${abundance})
             WHERE id = ${id}`;
-        return db.$executeRaw(Prisma.sql([sql]));
     }
 };
 

--- a/libs/db/taxonomy.ts
+++ b/libs/db/taxonomy.ts
@@ -531,7 +531,8 @@ export const sectionByName = (name: string): TE.TaskEither<Error, SectionApi[]> 
 export const deleteTaxonomyEntry = (id: number): TE.TaskEither<Error, DeleteResult> => {
     const doDelete = () => {
         // have to do raw calls since Prisma does not support cascade deletion.
-        const delSpeciesSql = `
+        return db.$transaction([
+            db.$executeRaw`
                 DELETE FROM species
                     WHERE id IN (
                     SELECT s.id
@@ -543,10 +544,9 @@ export const deleteTaxonomyEntry = (id: number): TE.TaskEither<Error, DeleteResu
                         INNER JOIN
                         species AS s ON s.id = st.species_id
                     WHERE f.id = ${id}
-                );
-            `;
-        const delTaxSql = `DELETE FROM taxonomy WHERE id = ${id}`;
-        return db.$transaction([db.$executeRaw(Prisma.sql([delSpeciesSql])), db.$executeRaw(Prisma.sql([delTaxSql]))]);
+                )`,
+            db.$executeRaw`DELETE FROM taxonomy WHERE id = ${id}`,
+        ]);
     };
 
     const toDeleteResult = (t: number[]): DeleteResult => {
@@ -628,16 +628,15 @@ const updateExistingGenera = (fam: FamilyUpsertFields) => {
 const updateExistingSpecies = (fam: FamilyUpsertFields) => {
     // I tried to do this with prisma but could not figure it out...
     return fam.genera.map((g) => {
-        const sql = `UPDATE species
-                SET name = [REPLACE](name, SUBSTRING(name, 1, INSTR(name, ' ') - 1), '${g.name}') 
+        return db.$executeRaw`UPDATE species
+                SET name = REPLACE(name, SUBSTRING(name, 1, INSTR(name, ' ') - 1), ${g.name})
             WHERE id IN (
                 SELECT st.species_id
                     FROM taxonomy AS t
                         INNER JOIN
                         speciestaxonomy AS st ON t.id = st.taxonomy_id
-                    WHERE t.id = ${g.id} 
-            );`;
-        return db.$executeRaw(Prisma.sql([sql]));
+                    WHERE t.id = ${g.id}
+            )`;
     });
 };
 
@@ -683,24 +682,22 @@ const createGenera = (fam: FamilyUpsertFields) => {
 };
 
 const familyUpdateSteps = (fam: FamilyUpsertFields): PrismaPromise<unknown>[] => {
-    const deltax = `DELETE FROM taxonomy
-        WHERE parent_id = ${fam.id} AND 
-            id NOT IN (${fam.genera.map((g) => g.id).join(',')});`;
-
-    const delsp = `DELETE FROM species
-        WHERE id IN (
-        SELECT species_id
-        FROM speciestaxonomy AS st
-            INNER JOIN
-            taxonomy AS t ON t.id = st.taxonomy_id
-        WHERE t.parent_id = ${fam.id} AND 
-            id NOT IN (${fam.genera.map((g) => g.id).join(',')}) 
-    );`;
+    const generaIds = fam.genera.map((g) => g.id);
 
     return [
         // delete any genera that are not part of the update
-        db.$executeRaw(Prisma.sql([delsp])),
-        db.$executeRaw(Prisma.sql([deltax])),
+        db.$executeRaw`DELETE FROM species
+            WHERE id IN (
+            SELECT species_id
+            FROM speciestaxonomy AS st
+                INNER JOIN
+                taxonomy AS t ON t.id = st.taxonomy_id
+            WHERE t.parent_id = ${fam.id} AND
+                id NOT IN (${Prisma.join(generaIds)})
+        )`,
+        db.$executeRaw`DELETE FROM taxonomy
+            WHERE parent_id = ${fam.id} AND
+                id NOT IN (${Prisma.join(generaIds)})`,
 
         // update any species names that are part of the updated genera
         ...updateExistingSpecies(fam),


### PR DESCRIPTION
## Summary

- Fix authentication bypass in protected API endpoints by adding `return` after 401 responses
- Fix SQL injection vulnerabilities by converting string interpolation to parameterized queries
- All raw SQL queries now use Prisma's tagged template literals for proper escaping

## Changes

### Auth Bypass Fix
- `libs/api/apipage.ts`: Added `return` after `res.status(401).end()` in `apiIdEndpoint` and `apiUpsertEndpoint`

### SQL Injection Fixes
| File | Fix |
|------|-----|
| `libs/db/gall.ts` | Parameterized DELETE species query |
| `libs/db/source.ts` | Parameterized DELETE source query |
| `libs/db/taxonomy.ts` | Parameterized DELETE/UPDATE queries, using `Prisma.join()` for IN clauses |
| `libs/db/gallhost.ts` | Parameterized INSERT/DELETE for host and speciesplace tables |
| `libs/db/place.ts` | Parameterized DELETE place query |
| `libs/db/species.ts` | Parameterized UPDATE abundance queries (fixed string injection vulnerability) |

## Test plan

- [x] Test gall CRUD operations in admin
- [x] Test host CRUD operations in admin
- [x] Test taxonomy family/genus editing
- [x] Test source deletion
- [x] Test place deletion
- [x] Verify unauthenticated requests to protected endpoints return 401