### PR TITLE
Fix SPA fallback and add production-identical local testing

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -4,7 +4,7 @@
 #   - api/  - Go REST API server
 #   - web/  - Svelte frontend
 
-.PHONY: dev dev-api dev-web storybook build test clean download-db help
+.PHONY: dev dev-api dev-web prod prod-api prod-web prod-embedded storybook build test clean download-db help
 
 # Start both API and web dev servers
 # API runs on :8080, web on :5173
@@ -27,6 +27,47 @@ dev-api:
 # Start only the web dev server
 dev-web:
 	cd web && npm run dev
+
+# Start both API and web servers in production mode locally
+# API runs on :8080, web preview on :4173
+# Requires `make build` first
+# Ctrl+C kills both
+prod:
+	@echo "Starting API server on http://localhost:8080"
+	@echo "Starting web preview server on http://localhost:4173"
+	@echo "Press Ctrl+C to stop both..."
+	@if [ -f .env ]; then set -a && . ./.env && set +a; fi && \
+		trap 'kill 0' INT && \
+		(cd api && ./bin/gallformers-api) & \
+		(cd web && npm run preview) & \
+		wait
+
+# Start only the API server in production mode (from built binary)
+prod-api:
+	@if [ -f .env ]; then set -a && . ./.env && set +a; fi && \
+		cd api && ./bin/gallformers-api
+
+# Start only the web preview server (production build)
+prod-web:
+	cd web && npm run preview
+
+# Production-identical local testing (RECOMMENDED for catching deploy issues)
+# Builds web, embeds in Go binary, runs Go server ONLY - exactly like Fly.io
+# No Vite, no preview server - all requests go through Go's static file handler
+prod-embedded:
+	@echo "Building web static files..."
+	cd web && npm run build
+	@echo "Copying to Go embed directory..."
+	rm -rf api/cmd/server/static/* 2>/dev/null || true
+	cp -r web/build/* api/cmd/server/static/
+	@echo "Rebuilding Go binary with embedded files..."
+	cd api && $(MAKE) build
+	@echo ""
+	@echo "Starting Go server on http://localhost:8080"
+	@echo "This is IDENTICAL to production - no Vite/Node involved!"
+	@echo ""
+	@if [ -f .env ]; then set -a && . ./.env && set +a; fi && \
+		cd api && ./bin/gallformers-api
 
 # Start Storybook component explorer
 storybook:
@@ -66,6 +107,12 @@ help:
 	@echo "  make dev-api    Start only the API server"
 	@echo "  make dev-web    Start only the web dev server"
 	@echo "  make storybook  Start Storybook component explorer (:6006)"
+	@echo ""
+	@echo "Production (local):"
+	@echo "  make prod          Start API (:8080) and web preview (:4173) together"
+	@echo "  make prod-api      Start only the API server (built binary)"
+	@echo "  make prod-web      Start only the web preview server"
+	@echo "  make prod-embedded Build & run Go with embedded files (IDENTICAL to Fly.io)"
 	@echo ""
 	@echo "Building:"
 	@echo "  make build      Build all components (web first, then API with embedded files)"

--- a/v2/api/cmd/server/main.go
+++ b/v2/api/cmd/server/main.go
@@ -222,7 +222,8 @@ func openapiSpecHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // spaFileServer serves static files with SPA fallback support.
-// If a file doesn't exist, it serves 404.html for client-side routing.
+// If a file doesn't exist, it serves 404.html with 200 status for client-side routing.
+// The 200 status is required for SPA frameworks to properly handle client-side routes.
 func spaFileServer(fsys fs.FS) http.Handler {
 	fileServer := http.FileServer(http.FS(fsys))
 
@@ -256,7 +257,7 @@ func spaFileServer(fsys fs.FS) http.Handler {
 		}
 
 		// Serve 404.html for SPA routing (let client-side handle it)
-		// Read 404.html content
+		// Read 404.html content and serve with 200 status for proper SPA behavior
 		content, err := fs.ReadFile(fsys, "404.html")
 		if err != nil {
 			// No 404.html, return plain 404
@@ -265,7 +266,7 @@ func spaFileServer(fsys fs.FS) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusOK)
 		w.Write(content)
 	})
 }


### PR DESCRIPTION
## Summary
- Fix SPA fallback returning 404 status instead of 200, which broke client-side navigation to non-prerendered routes like `/id`
- Add `make prod-embedded` target for production-identical local testing (builds web, embeds in Go binary, runs Go server only - exactly like Fly.io)
- Add `make prod`, `make prod-api`, `make prod-web` targets for other production testing scenarios

## Root Cause
The Go server's `spaFileServer` was serving `404.html` with HTTP 404 status. SvelteKit interprets 404 as a real "not found" error and refuses to render the page via client-side routing.

## Fix
Changed `http.StatusNotFound` to `http.StatusOK` when serving the SPA fallback. The file is named `404.html` (SvelteKit convention) but must return 200 for SPA routing to work.

## Why This Wasn't Caught
`make dev` uses Vite's dev server which has full route knowledge - it handles `/id` correctly because it knows it's a valid route. Production uses only the Go server with static files, which falls back to `404.html` for unknown paths.

The new `make prod-embedded` target would have caught this issue by testing the exact production setup locally.

## Test plan
- [x] Verified `/id` returns 200 with `make prod-embedded`
- [ ] Test ID page navigation works on deployed site after merge