### PR TITLE
Update Phoenix proposal with v2_old migration approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,11 @@ Gallformers (gallformers.org) is a comprehensive online database and reference g
 - **Education**: Providing guides, keys, and reference materials about galls
 - **Research**: Serving as a data repository for researchers and naturalists
 
-## Technical Stack
+## V1 and V2
+There are two versions of the application. V1 is at the root and is a stable legacy implementation. We only fix bugs in it.
+V2 is the bulk of work, it is all in the v2/ directory. See the CLAUDE.md in that directory for more details.
+
+## V1 Technical Stack
 
 ### Frontend
 - **Next.js 14** (React-based framework) - Server-side rendering and static generation
@@ -303,69 +307,39 @@ This project uses **watchmen** for time tracking. A hook automatically starts th
 
 ## Git Workflow
 
-**IMPORTANT: Never checkout `main` directly.** The beads daemon uses a sparse worktree on `main` for auto-sync. Attempting to checkout `main` will fail.
-
 **Push approval rules:**
 | Change Type | Approval Required | Notes |
 |-------------|-------------------|-------|
 | Beads (`.beads/`) | No | Daemon auto-syncs to main |
-| Specs (`/openspec/`) | No | But must be manually pushed to main |
 | Everything else | **Yes** | Always ask user before pushing to main |
-
-**Workflow for small work (bugs, specs, small features):**
-```bash
-# Start from origin/main
-git fetch origin
-git checkout -b fix/descriptive-name origin/main
-
-# Do work, commit
-git add <files>
-git commit -m "Description"
-
-# For specs: push to main immediately
-git push origin fix/descriptive-name:main
-git checkout --detach origin/main
-git branch -d fix/descriptive-name
-
-# For code: ASK USER FIRST, then push if approved
-```
-
-**Workflow for large features:**
-```bash
-# Create a worktree for the feature
-git worktree add ../gallformers-feature-name -b feature-name origin/main
-
-# Work in that directory until complete
-# When ready to merge: ASK USER FOR APPROVAL
-```
-
-**Specs rule:** When specs in `/openspec/` are modified (even while on a feature branch), ensure they get pushed to main. Create a separate branch from `origin/main` if needed.
-
-**Beads:** The daemon (auto-commit, auto-push, auto-pull) handles all beads sync automatically.
 
 **Commit messages:** Present tense, imperative mood.
 
+CRITICAL: Never push to main without explicit approval from the user, unless it is beads changes only.
+
 ## Multi-Agent Workflow
 
-Multiple agents work in parallel using separate git worktrees.
+Multiple agents can work in parallel using separate git worktrees.
 
 **Worktree locations:**
 | Worktree | Branch | Role |
 |----------|--------|------|
-| `~/dev/gallformers` | (varies) | Coding Agent 1 |
-| `~/dev/gallformers-code2` | code2 | Coding Agent 2 |
-| `~/dev/gallformers-bugfix` | bugfix | Bug Fixer |
+| `~/dev/gallformers-code1` | [name based on work being done] | Coding Agent 1 |
+| `~/dev/gallformers-code2` | [name based on work being done] | Coding Agent 2 |
+| `~/dev/gallformers-bugfix` | [name based on work being done] | Bug Fixer |
 | `~/dev/gallformers-planning` | planning | Planner + Coordinator |
 
 **Rules for all agents:**
 - Stay in your assigned worktree - never modify files in other worktrees
 - Before starting work on a beads issue, claim it: `bd update <id> --status=in_progress`
+- If there is not already a branch, make one. Name it after the work being done.
 - Commit your work before ending the session
+- NEVER push to main unless you are explicitly told to
 - Do not run git operations that affect other branches
 
 **Role-specific rules:**
 
-*Coding Agents (gallformers, gallformers-code2):*
+*Coding Agents (gallformers-code1, gallformers-code2):*
 - Full code modification access
 - Run builds, tests as needed
 

--- a/openspec/changes/adopt-phoenix-liveview/design.md
+++ b/openspec/changes/adopt-phoenix-liveview/design.md
@@ -1,0 +1,535 @@
+# Design: Phoenix + LiveView Architecture
+
+## Context
+
+V2 was being built as a Go API + SvelteKit frontend. After evaluating alternatives (pure SPA, Go + HTMX, Phoenix), the decision is to adopt Phoenix with LiveView for a unified full-stack Elixir solution.
+
+**Stakeholders**:
+- Site admins (need instant feedback on changes)
+- End users (need fast, reliable access to data)
+- Developer (needs simple, maintainable architecture with excellent DX)
+
+**Constraints**:
+- Low traffic most of the time, occasionally bursty
+- Primary use case is ID tool (interactive)
+- SEO is nice-to-have, not critical
+- No budget for expensive infrastructure
+- Single maintainer with strong FP background
+
+## Goals / Non-Goals
+
+**Goals**:
+- Admin changes visible immediately without any cache invalidation
+- Server renders full HTML (good SEO, works without JS)
+- Excellent developer experience (LiveView, hot reload, error pages)
+- Single language/ecosystem (Elixir)
+- Real-time capabilities built-in
+- Type-safe with dialyzer (optional but available)
+
+**Non-Goals**:
+- Offline support (not needed for this use case)
+- Sub-100ms page loads (acceptable if under 500ms)
+- GraphQL API (REST is sufficient)
+
+## Decisions
+
+### Decision 1: Use Phoenix with LiveView
+
+**What**: Full-stack Elixir with Phoenix framework and LiveView for interactive UI.
+
+**Why**:
+- LiveView: Server-rendered real-time UI without client-side JS framework
+- Ecto: Excellent database layer with composable queries and changesets
+- PubSub: Built-in real-time broadcast for admin updates
+- Conventions: Strong conventions reduce decision fatigue
+- Maintainer fit: FP background (Scala/Akka) transfers directly
+
+**Example LiveView**:
+```elixir
+defmodule GallformersWeb.GlossaryLive do
+  use GallformersWeb, :live_view
+
+  def mount(_params, _session, socket) do
+    entries = Glossary.list_entries()
+    {:ok, assign(socket, entries: entries, sort_by: :word, sort_dir: :asc)}
+  end
+
+  def handle_event("sort", %{"column" => column}, socket) do
+    column = String.to_existing_atom(column)
+    {sort_by, sort_dir} = toggle_sort(socket.assigns, column)
+    entries = Glossary.list_entries(sort_by: sort_by, sort_dir: sort_dir)
+    {:noreply, assign(socket, entries: entries, sort_by: sort_by, sort_dir: sort_dir)}
+  end
+end
+```
+
+**Alternative considered**: Go + Templ + HTMX
+- Also excellent, but Phoenix provides more integrated solution
+- LiveView handles what would require HTMX + Alpine.js in Go stack
+
+### Decision 2: Ecto with SQLite
+
+**What**: Use Ecto ORM with ecto_sqlite3 adapter for database access.
+
+**Why**:
+- Composable queries (pipe-based, very Elixir-idiomatic)
+- Changesets for validation (validation is data, not side effects)
+- Explicit preloading (no N+1 surprises)
+- Works with existing SQLite database
+
+**Schema example**:
+```elixir
+defmodule Gallformers.Species do
+  use Ecto.Schema
+
+  schema "species" do
+    field :name, :string
+    field :abundance, :string
+    field :datacomplete, :boolean
+
+    belongs_to :taxonomy, Gallformers.Taxonomy
+    has_many :images, Gallformers.Image
+    many_to_many :hosts, Gallformers.Host, join_through: "specieshosts"
+  end
+
+  def changeset(species, attrs) do
+    species
+    |> cast(attrs, [:name, :abundance, :datacomplete])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 1, max: 255)
+    |> unique_constraint(:name)
+  end
+end
+```
+
+**Composable queries**:
+```elixir
+def filter_galls(params) do
+  Gall
+  |> maybe_filter_host(params[:host_id])
+  |> maybe_filter_colors(params[:colors])
+  |> maybe_filter_shapes(params[:shapes])
+  |> preload([:species, :hosts, :images])
+  |> Repo.all()
+end
+
+defp maybe_filter_host(query, nil), do: query
+defp maybe_filter_host(query, host_id) do
+  from g in query,
+    join: h in assoc(g, :hosts),
+    where: h.id == ^host_id
+end
+```
+
+### Decision 3: LiveView for all interactivity
+
+**What**: Use LiveView for search, ID tool, forms, and all dynamic features.
+
+**Why**:
+- No client-side state management needed
+- Server maintains state, pushes diffs over WebSocket
+- Forms with real-time validation via changesets
+- URL state via `handle_params` and `push_patch`
+
+**Search example**:
+```elixir
+def handle_event("search", %{"query" => query}, socket) do
+  results = Search.find(query)
+  {:noreply, assign(socket, results: results, query: query)}
+end
+```
+
+**URL state for ID tool**:
+```elixir
+def handle_params(params, _uri, socket) do
+  filters = parse_filters(params)
+  results = IDTool.filter_galls(filters)
+  {:noreply, assign(socket, filters: filters, results: results)}
+end
+
+def handle_event("filter_change", %{"host" => host_id}, socket) do
+  filters = Map.put(socket.assigns.filters, :host_id, host_id)
+  {:noreply, push_patch(socket, to: ~p"/id?#{filters}")}
+end
+```
+
+**Alternative considered**: HTMX-style approach with dead views + partials
+- LiveView is simpler - no need to manage separate partial endpoints
+- Built-in form handling with changesets
+
+### Decision 4: PubSub for real-time updates
+
+**What**: Use Phoenix PubSub to broadcast admin changes to all connected clients.
+
+**Why**:
+- Admin saves species → broadcast to all users viewing that species
+- No cache invalidation logic needed
+- Built into Phoenix, zero configuration
+
+**Example**:
+```elixir
+# In admin context after save
+def update_species(species, attrs) do
+  case Repo.update(Species.changeset(species, attrs)) do
+    {:ok, species} ->
+      Phoenix.PubSub.broadcast(Gallformers.PubSub, "species:#{species.id}", {:species_updated, species})
+      {:ok, species}
+    error -> error
+  end
+end
+
+# In public LiveView
+def mount(%{"id" => id}, _session, socket) do
+  if connected?(socket) do
+    Phoenix.PubSub.subscribe(Gallformers.PubSub, "species:#{id}")
+  end
+  species = Species.get!(id)
+  {:ok, assign(socket, species: species)}
+end
+
+def handle_info({:species_updated, species}, socket) do
+  {:noreply, assign(socket, species: species)}
+end
+```
+
+### Decision 5: JS hooks for complex visualizations
+
+**What**: Use Phoenix LiveView hooks for features that need JavaScript (maps, uploads).
+
+**Why**:
+- Clean boundary: server manages data, JS manages visualization
+- LiveView handles data passing, hook handles rendering
+- No need for separate "islands" build process
+
+**Range map example**:
+```elixir
+# In template
+<div id="range-map"
+     phx-hook="RangeMap"
+     data-range={Jason.encode!(@range_data)}>
+</div>
+```
+
+```javascript
+// In app.js
+Hooks.RangeMap = {
+  mounted() {
+    const data = JSON.parse(this.el.dataset.range)
+    this.map = initMapLibre(this.el, data)
+  },
+  updated() {
+    const data = JSON.parse(this.el.dataset.range)
+    updateMapData(this.map, data)
+  },
+  destroyed() {
+    this.map?.remove()
+  }
+}
+```
+
+**Hooks needed**:
+- Range map (MapLibre)
+- Image upload with preview
+- Any third-party JS components
+
+### Decision 6: HEEx templates with Tailwind
+
+**What**: Use HEEx (HTML + Elixir) templates with existing Tailwind classes.
+
+**Why**:
+- HEEx is the standard Phoenix templating
+- Compile-time checks for assigns
+- Tailwind classes copy directly from SvelteKit
+
+**Example**:
+```heex
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-gf-maroon mb-4"><%= @species.name %></h1>
+
+  <.card title="Hosts">
+    <ul>
+      <%= for host <- @species.hosts do %>
+        <li>
+          <.link navigate={~p"/host/#{host.id}"} class="text-gf-maroon hover:underline">
+            <%= host.name %>
+          </.link>
+        </li>
+      <% end %>
+    </ul>
+  </.card>
+</div>
+```
+
+**Function components**:
+```elixir
+defmodule GallformersWeb.Components do
+  use Phoenix.Component
+
+  attr :title, :string, required: true
+  slot :inner_block, required: true
+
+  def card(assigns) do
+    ~H"""
+    <div class="bg-white rounded border border-gray-200 shadow-sm">
+      <div class="px-4 py-3 border-b border-gray-200">
+        <h2 class="text-xl font-semibold text-gf-maroon"><%= @title %></h2>
+      </div>
+      <div class="p-4">
+        <%= render_slot(@inner_block) %>
+      </div>
+    </div>
+    """
+  end
+end
+```
+
+### Decision 7: Phoenix contexts for domain logic
+
+**What**: Organize business logic into contexts (bounded modules).
+
+**Structure**:
+```
+lib/gallformers/
+├── species.ex          # Species context
+├── species/
+│   ├── gall.ex         # Gall schema
+│   ├── host.ex         # Host schema
+│   └── taxonomy.ex     # Taxonomy schema
+├── glossary.ex         # Glossary context
+├── search.ex           # Search context
+├── id_tool.ex          # ID tool filtering logic
+└── accounts.ex         # Admin accounts context
+```
+
+**Context example**:
+```elixir
+defmodule Gallformers.Species do
+  alias Gallformers.Repo
+  alias Gallformers.Species.{Gall, Host, Taxonomy}
+
+  def get_gall!(id) do
+    Gall
+    |> Repo.get!(id)
+    |> Repo.preload([:hosts, :images, :taxonomy])
+  end
+
+  def list_galls(opts \\ []) do
+    Gall
+    |> apply_filters(opts)
+    |> Repo.all()
+  end
+
+  def update_gall(%Gall{} = gall, attrs) do
+    gall
+    |> Gall.changeset(attrs)
+    |> Repo.update()
+    |> broadcast_change()
+  end
+end
+```
+
+### Decision 8: Authentication with Auth0
+
+**What**: Continue using Auth0 via ueberauth_auth0.
+
+**Why**:
+- Already configured for v1/v2
+- ueberauth provides standard Phoenix integration
+- Session-based auth works well with LiveView
+
+**Implementation**:
+```elixir
+# In router
+pipeline :browser do
+  plug :fetch_session
+  plug :fetch_live_flash
+  plug :put_root_layout, {GallformersWeb.Layouts, :root}
+  plug :protect_from_forgery
+  plug :put_secure_browser_headers
+  plug :fetch_current_user
+end
+
+pipeline :admin do
+  plug :require_authenticated_user
+  plug :require_admin_role
+end
+
+scope "/admin", GallformersWeb.Admin do
+  pipe_through [:browser, :admin]
+
+  live "/species", SpeciesLive.Index
+  live "/species/:id/edit", SpeciesLive.Edit
+end
+```
+
+### Decision 9: Markdown with earmark
+
+**What**: Server-side markdown rendering with earmark, glossary linking as post-processor.
+
+**Implementation**:
+```elixir
+defmodule Gallformers.Markdown do
+  def render(source) do
+    source
+    |> Earmark.as_html!()
+    |> link_glossary_terms()
+  end
+
+  defp link_glossary_terms(html) do
+    terms = Glossary.list_terms()
+    Enum.reduce(terms, html, fn term, acc ->
+      regex = ~r/\b#{Regex.escape(term.word)}\b/i
+      Regex.replace(regex, acc, fn match ->
+        ~s(<a href="/glossary##{String.downcase(term.word)}" class="text-gf-maroon hover:underline">#{match}</a>)
+      end)
+    end)
+  end
+end
+```
+
+### Decision 10: SEO implementation
+
+**What**: Standard Phoenix SEO with meta tags, Open Graph, and sitemap.
+
+**Meta component**:
+```elixir
+def meta_tags(assigns) do
+  ~H"""
+  <title><%= @title %> | Gallformers</title>
+  <meta name="description" content={@description} />
+  <link rel="canonical" href={@canonical_url} />
+
+  <meta property="og:title" content={@title} />
+  <meta property="og:description" content={@description} />
+  <meta property="og:image" content={@image_url} />
+  <meta property="og:url" content={@canonical_url} />
+  <meta property="og:type" content="website" />
+  """
+end
+```
+
+**Sitemap**: Generate with `sitemap` library or custom controller.
+
+**Robots.txt**: Static file or controller allowing public, disallowing admin.
+
+### Decision 11: Directory structure
+
+```
+v2/
+├── lib/
+│   ├── gallformers/              # Business logic (contexts)
+│   │   ├── species.ex
+│   │   ├── species/
+│   │   │   ├── gall.ex
+│   │   │   ├── host.ex
+│   │   │   └── taxonomy.ex
+│   │   ├── glossary.ex
+│   │   ├── search.ex
+│   │   ├── id_tool.ex
+│   │   └── accounts.ex
+│   ├── gallformers_web/          # Web layer
+│   │   ├── components/           # Reusable UI components
+│   │   │   ├── layouts.ex
+│   │   │   └── core_components.ex
+│   │   ├── live/                 # LiveView modules
+│   │   │   ├── gall_live.ex
+│   │   │   ├── host_live.ex
+│   │   │   ├── glossary_live.ex
+│   │   │   ├── search_live.ex
+│   │   │   ├── id_live.ex
+│   │   │   └── admin/
+│   │   │       ├── species_live.ex
+│   │   │       └── ...
+│   │   ├── controllers/          # Non-LiveView (API, auth callbacks)
+│   │   │   ├── api/
+│   │   │   └── auth_controller.ex
+│   │   └── router.ex
+│   └── gallformers.ex            # Application entry
+├── priv/
+│   └── static/                   # Static assets
+│       ├── css/
+│       ├── js/
+│       └── images/
+├── assets/                       # Asset sources
+│   ├── css/app.css
+│   ├── js/app.js
+│   └── js/hooks/
+│       └── range_map.js
+├── config/                       # Configuration
+├── test/                         # Tests
+└── mix.exs                       # Dependencies
+```
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Elixir learning curve | Low | Maintainer has strong FP background |
+| Smaller ecosystem than JS/Go | Low | Phoenix ecosystem covers all needs |
+| LLM code quality | Medium | Review Elixir idioms, provide patterns |
+| WebSocket scalability | Low | Single instance is fine; Fly.io handles gracefully |
+| SQLite with Ecto maturity | Low | ecto_sqlite3 is stable, used in production |
+
+## Migration Plan
+
+**Critical constraint**: Visual design MUST match current V2 SvelteKit site.
+
+**Key principles**:
+1. **Deploy early, deploy often** - Get something running in prod ASAP
+2. **One page at a time** - Build, deploy, verify visual parity, then move on
+3. **v2_old is the spec** - Reference the existing code, don't create separate docs
+4. **CI from day one** - Catch issues early
+5. **Home page first** - Proves the architecture works end-to-end
+
+### Phase 0: Code Migration
+- Move `v2/` to `v2_old/`
+- Create new `v2/` for Phoenix project
+- Update root CLAUDE.md to reflect new structure
+
+### Phase 1: Foundation + CI + First Deploy
+- Set up Phoenix project with CI pipeline
+- Create `v2/CLAUDE.md` with agent instructions
+- Configure Ecto with SQLite
+- Create base layout with Tailwind (port from v2_old)
+- Deploy to Fly.io (even with placeholder content)
+
+### Phase 2: Home Page (Tracer Bullet)
+- Create minimal Ecto schemas needed for home page
+- Implement HomeLive with random gall feature
+- Verify visual parity with v2_old
+- Deploy and verify in production
+
+**Milestone**: Site is live with working home page
+
+### Phase 3: Ecto Schemas + Components
+- Complete all Ecto schemas
+- Build shared UI components
+- Reference v2_old code for data model and styling
+
+### Phase 4: Public Pages
+- Build one page at a time
+- Deploy after each page
+- Verify visual parity before moving on
+
+### Phase 5: Interactive Features
+- Implement search LiveView
+- Implement ID tool LiveView
+- Add range map JS hook
+
+### Phase 6: Admin
+- Implement admin LiveViews with forms
+- Add PubSub for real-time updates
+- Integrate Auth0
+
+### Phase 7: API
+- Add JSON API endpoints matching v2_old patterns
+- Document API using v2_old style (V1_V2_DIFFERENCES.md format)
+
+### Phase 8: Cleanup
+- Final visual parity sign-off
+- Remove v2_old directory
+- Update documentation
+
+## Rollback Strategy
+
+Keep `v2_old/` until Phoenix is fully deployed and verified. The code in v2_old serves as both the spec and the rollback target.

--- a/openspec/changes/adopt-phoenix-liveview/proposal.md
+++ b/openspec/changes/adopt-phoenix-liveview/proposal.md
@@ -1,0 +1,112 @@
+# Change: Adopt Phoenix + LiveView Architecture
+
+## Why
+
+The V2 frontend uses SvelteKit with Static Site Generation (SSG). This causes a fundamental problem:
+
+**When admins edit data, public pages show stale content until rebuild.**
+
+This is not a bug - it's inherent to SSG. The HTML is baked at build time. No amount of cache headers fixes it.
+
+We explored several solutions:
+1. **Pure SPA** (convert-v2-to-spa proposal) - Solves freshness but fights SvelteKit's SSR-first design
+2. **Go + Templ + HTMX** (adopt-templ-htmx proposal) - Solid approach but requires learning templ, less mature ecosystem
+3. **Phoenix LiveView** - Full-stack solution with best-in-class real-time UI
+
+The chosen approach: **Phoenix + LiveView**
+
+This architecture:
+- Renders HTML server-side with HEEx templates
+- LiveView maintains persistent WebSocket connection
+- UI updates push automatically - no manual cache invalidation
+- Admin edits are immediately visible everywhere
+- Single Elixir codebase - no JSON API contract, no client-side state
+
+## What Changes
+
+### Architecture Changes
+
+- **Remove SvelteKit entirely** - No more `v2/web/` directory
+- **Remove Go API** - Replaced by Phoenix
+- **Phoenix renders all HTML** - Using HEEx templates and LiveView
+- **LiveView for interactivity** - Search, ID tool, forms use LiveView
+- **PubSub for real-time updates** - Admin edits broadcast to all connected clients
+- **JS hooks for complex UI** - Range maps, image upload that truly need JS
+
+### Code Changes
+
+- Move `v2/` to `v2_old/` (Go + SvelteKit preserved as reference)
+- Create new Phoenix application in `v2/`
+- Ecto schemas mapping to existing SQLite database
+- LiveView modules for each page
+- HEEx templates with Tailwind styling
+- Use `v2_old/` as the spec for porting (the code IS the documentation)
+- Remove `v2_old/` after migration complete and visual parity verified
+
+### What Stays the Same
+
+- SQLite database (same schema, accessed via Ecto)
+- S3 image storage (public URLs)
+- Auth0 authentication (via ueberauth)
+- Fly.io deployment (excellent Phoenix support)
+- Domain/DNS
+- Visual design (same Tailwind classes)
+
+## Impact
+
+- **Affected specs**: `v2-infrastructure`
+- **Supersedes**: `convert-v2-to-spa` proposal
+- **Affected code**: All of `v2/` replaced
+- **Build process**: Mix (no Node.js needed except for Tailwind)
+- **SEO**: Excellent - server renders full HTML
+
+## Resolved Questions
+
+### 1. Why Phoenix over Go + HTMX?
+
+Both are excellent choices. Phoenix was selected because:
+- LiveView provides HTMX-like simplicity with more power (real-time, form handling)
+- Ecto changesets handle validation elegantly
+- Maintainer has strong FP background (Scala, fp-ts, Akka) - Elixir is natural fit
+- Single language for entire stack
+- Built-in real-time (PubSub) without additional setup
+
+### 2. What about the existing Go code?
+
+The Go API logic transfers to Elixir - same concepts, different syntax:
+- sqlc queries → Ecto queries
+- Chi handlers → Phoenix controllers/LiveView
+- Go structs → Elixir schemas
+
+### 3. What about admin complexity?
+
+LiveView handles all admin use cases:
+- Simple forms: LiveView with changesets
+- Tag editors: LiveView with list state
+- Complex features (drag-drop uploads): JS hooks
+
+### 4. What about range maps?
+
+JavaScript hook. LiveView embeds GeoJSON data, JS hook initializes MapLibre. Clean boundary between server state and JS visualization.
+
+### 5. What about markdown/glossary linking?
+
+Server-side with earmark or mdex. Glossary terms auto-linked during render.
+
+### 6. Performance?
+
+- Initial page load: Full HTML rendered server-side (~5-20ms)
+- Subsequent interactions: WebSocket diffs (~1-5ms perceived latency)
+- No cold cache concerns - LiveView state is always current
+
+### 7. LLM-friendliness?
+
+Phoenix + Elixir is moderately LLM-friendly:
+- Consistent patterns (Phoenix conventions)
+- Well-documented
+- Smaller training corpus than JS/Go but high quality
+- Maintainer can review and correct Elixir idioms
+
+## Open Questions
+
+None currently. Tracer bullet (glossary page) validated the approach. Ready for implementation.

--- a/openspec/changes/adopt-phoenix-liveview/tasks.md
+++ b/openspec/changes/adopt-phoenix-liveview/tasks.md
@@ -1,0 +1,404 @@
+# Tasks: Adopt Phoenix + LiveView Architecture
+
+## Decisions
+- **Framework**: Phoenix + LiveView (replacing SvelteKit + Go)
+- **Database**: Ecto with ecto_sqlite3
+- **Interactivity**: LiveView for all dynamic features
+- **Client-side**: JS hooks only for maps and complex uploads
+- **Styling**: Tailwind CSS (ported from SvelteKit)
+- **Auth**: Auth0 via ueberauth
+
+## 0. Code Migration
+
+- [ ] 0.1 Move existing `v2/` directory to `v2_old/`
+- [ ] 0.2 Create new `v2/` directory for Phoenix project
+- [ ] 0.3 Update root `CLAUDE.md` to reflect:
+  - New v2 is Phoenix + LiveView + Ecto
+  - v2_old contains the Go + SvelteKit implementation
+  - v2_old serves as reference for porting and will be removed after migration
+
+**Note**: We do NOT need separate documentation of routes and API endpoints (previous 0.2/0.3). The code in `v2_old/` IS the documentation - use it as reference when porting.
+
+## 1. Foundation Setup
+
+### 1.1 Phoenix Project Bootstrap
+- [ ] 1.1.1 Create new Phoenix project with `mix phx.new gallformers --database sqlite3`
+- [ ] 1.1.2 Configure ecto_sqlite3 to use existing database path
+- [ ] 1.1.3 Verify `mix phx.server` starts successfully
+- [ ] 1.1.4 Configure `.formatter.exs` for consistent code style
+
+### 1.2 CI Pipeline (set up early to catch issues)
+- [ ] 1.2.1 Add `mix format --check-formatted` to CI
+- [ ] 1.2.2 Add `mix test` to CI
+- [ ] 1.2.3 Add `mix credo` for code quality (optional)
+- [ ] 1.2.4 Add `mix dialyzer` for type checking (optional)
+
+### 1.3 Documentation
+- [ ] 1.3.1 Create `v2/CLAUDE.md` with:
+  - Scope and isolation rules (stay in v2/)
+  - Development commands (mix phx.server, etc.)
+  - Reference to v2_old for porting guidance
+  - Tailwind styling patterns (copy from current v2/CLAUDE.md)
+  - LiveView patterns as they emerge
+
+### 1.4 Tailwind Configuration
+- [ ] 1.4.1 Copy custom colors from `v2_old/web/src/app.css` to Tailwind config
+- [ ] 1.4.2 Add `gf-maroon`, `gf-sky-blue`, `gf-autumn`, `cadet-blue`, `canary` colors
+- [ ] 1.4.3 Configure League Spartan font
+- [ ] 1.4.4 Port any custom utility classes from SvelteKit
+
+### 1.5 Base Layout
+- [ ] 1.5.1 Create `root.html.heex` with HTML skeleton, meta tags
+- [ ] 1.5.2 Create `app.html.heex` with site structure
+- [ ] 1.5.3 Create header component matching SvelteKit design
+- [ ] 1.5.4 Create footer component matching SvelteKit design
+- [ ] 1.5.5 Create navigation component
+
+### 1.6 Static Assets
+- [ ] 1.6.1 Copy favicon, apple-touch-icon from `v2_old/web/static/`
+- [ ] 1.6.2 Copy brand images (cynipid_R.svg, etc.)
+- [ ] 1.6.3 Configure static file serving with cache headers
+
+## 2. First Deployment (deploy early, deploy often)
+
+### 2.1 Fly.io Configuration
+- [ ] 2.1.1 Create `fly.toml` for Phoenix app
+- [ ] 2.1.2 Configure SQLite volume mount
+- [ ] 2.1.3 Set environment variables (AUTH0_*, DATABASE_PATH, etc.)
+- [ ] 2.1.4 Create release configuration in `mix.exs`
+- [ ] 2.1.5 Create `Dockerfile` for Phoenix release
+- [ ] 2.1.6 Configure health check endpoint
+
+### 2.2 Initial Deploy
+- [ ] 2.2.1 Test Docker build locally
+- [ ] 2.2.2 Deploy to Fly.io staging
+- [ ] 2.2.3 Verify site loads (even if just layout with placeholder content)
+- [ ] 2.2.4 Set up deployment pipeline for continuous deploys
+
+## 3. Home Page (Tracer Bullet)
+
+Goal: Get the core site working with a real page. Once home page works, we have confidence.
+
+### 3.1 Minimal Ecto Schemas
+- [ ] 3.1.1 Create `Species` schema (just fields needed for home page)
+- [ ] 3.1.2 Create `Image` schema with S3 URL handling
+- [ ] 3.1.3 Create `Gallformers.Species` context with `random_gall/0` function
+
+### 3.2 Home Page LiveView
+- [ ] 3.2.1 Create `HomeLive` - home page with random gall feature
+- [ ] 3.2.2 Verify visual parity with `v2_old/web/src/routes/+page.svelte`
+- [ ] 3.2.3 Deploy and verify in production
+
+**Milestone: Site is live with working home page**
+
+## 4. Complete Ecto Schemas
+
+### 4.1 Core Schemas
+- [ ] 4.1.1 Complete `Species` schema with all fields
+- [ ] 4.1.2 Create `Gall` schema with all fields and associations
+- [ ] 4.1.3 Create `Host` schema with all fields
+- [ ] 4.1.4 Create `Taxonomy` schema with parent relationship
+- [ ] 4.1.5 Create `Source` schema
+- [ ] 4.1.6 Create `Glossary` schema
+
+### 4.2 Join Tables
+- [ ] 4.2.1 Map `specieshosts` join table
+- [ ] 4.2.2 Map `gallhost` join table
+- [ ] 4.2.3 Map filter field join tables (colors, shapes, textures, etc.)
+- [ ] 4.2.4 Map `speciesplace` for range data
+
+### 4.3 Filter Fields
+- [ ] 4.3.1 Create schemas for filter field tables (color, shape, texture, etc.)
+- [ ] 4.3.2 Create associations from Gall to filter fields
+
+### 4.4 Contexts
+- [ ] 4.4.1 Create `Gallformers.Species` context with CRUD functions
+- [ ] 4.4.2 Create `Gallformers.Hosts` context
+- [ ] 4.4.3 Create `Gallformers.Taxonomy` context
+- [ ] 4.4.4 Create `Gallformers.Glossary` context
+- [ ] 4.4.5 Create `Gallformers.Sources` context
+- [ ] 4.4.6 Create `Gallformers.Search` context
+- [ ] 4.4.7 Create `Gallformers.IDTool` context with filtering logic
+
+## 5. Shared Components
+
+### 5.1 UI Components
+- [ ] 5.1.1 Create `card` component matching SvelteKit style
+- [ ] 5.1.2 Create `loading_spinner` component
+- [ ] 5.1.3 Create `error_message` component
+- [ ] 5.1.4 Create `pagination` component
+- [ ] 5.1.5 Create `alert` component (success, error, info)
+- [ ] 5.1.6 Create `info_tip` tooltip component
+
+### 5.2 Form Components
+- [ ] 5.2.1 Create `input` component with error display
+- [ ] 5.2.2 Create `textarea` component
+- [ ] 5.2.3 Create `select` component
+- [ ] 5.2.4 Create `checkbox` component
+- [ ] 5.2.5 Create `button` component with variants
+
+### 5.3 Data Display Components
+- [ ] 5.3.1 Create `image_gallery` component with lazy loading
+- [ ] 5.3.2 Create `species_card` component
+- [ ] 5.3.3 Create `host_list` component
+- [ ] 5.3.4 Create `source_citation` component
+- [ ] 5.3.5 Create `taxonomy_breadcrumb` component
+- [ ] 5.3.6 Create `data_completeness_indicator` component
+- [ ] 5.3.7 Create `edit_button` component (for admin links)
+
+## 6. Public Pages (LiveViews)
+
+Build one page at a time, deploy after each, verify visual parity.
+
+### 6.1 Content Pages
+- [ ] 6.1.1 Create `AboutLive` - about page
+- [ ] 6.1.2 Create `FilterGuideLive` - filter guide page
+- [ ] 6.1.3 Create `ResourcesLive` - resources page
+- [ ] 6.1.4 Create `GlossaryLive` - glossary with sorting
+- [ ] 6.1.5 Create `RefIndexLive` - reference article index
+
+### 6.2 Entity Pages
+- [ ] 6.2.1 Create `GallLive` - gall/species detail page
+- [ ] 6.2.2 Create `HostLive` - host detail page
+- [ ] 6.2.3 Create `FamilyLive` - family listing page
+- [ ] 6.2.4 Create `GenusLive` - genus listing page
+- [ ] 6.2.5 Create `SourceLive` - source detail page
+- [ ] 6.2.6 Create `SectionLive` - section listing page
+- [ ] 6.2.7 Create `PlaceLive` - place detail page
+
+### 6.3 Error Pages
+- [ ] 6.3.1 Create custom 404 page matching site design
+- [ ] 6.3.2 Create custom 500 page matching site design
+- [ ] 6.3.3 Configure error view in endpoint
+
+## 7. Search (LiveView)
+
+- [ ] 7.1 Create `SearchLive` with search input
+- [ ] 7.2 Implement `handle_event("search", ...)` with debounce
+- [ ] 7.3 Display results grouped by type (galls, hosts, sources)
+- [ ] 7.4 Add keyboard navigation for results
+- [ ] 7.5 Implement URL sync with `push_patch`
+
+## 8. ID Tool (LiveView)
+
+- [ ] 8.1 Create `IDLive` with filter form
+- [ ] 8.2 Implement `handle_params` for URL-based filter state
+- [ ] 8.3 Implement filter change handlers with `push_patch`
+- [ ] 8.4 Create results grid component
+- [ ] 8.5 Implement host picker (LiveView typeahead)
+- [ ] 8.6 Implement genus picker (LiveView typeahead)
+- [ ] 8.7 Port all filter options (color, shape, texture, location, etc.)
+- [ ] 8.8 Test back/forward navigation preserves filters
+
+## 9. Explore Page (LiveView)
+
+- [ ] 9.1 Create `ExploreLive` with browse options
+- [ ] 9.2 Implement browse-by-family
+- [ ] 9.3 Implement browse-by-host
+- [ ] 9.4 Add pagination for large result sets
+
+## 10. Range Map (JS Hook)
+
+- [ ] 10.1 Create `RangeMap` hook in `assets/js/hooks/range_map.js`
+- [ ] 10.2 Configure MapLibre GL JS
+- [ ] 10.3 Implement `mounted()` to initialize map with data
+- [ ] 10.4 Implement `updated()` to handle data changes
+- [ ] 10.5 Style map to match current design
+- [ ] 10.6 Create HEEx component `range_map` with hook binding
+- [ ] 10.7 Test with real range data
+
+## 11. Admin Pages (LiveView)
+
+### 11.1 Admin Foundation
+- [ ] 11.1.1 Configure Auth0 with ueberauth_auth0
+- [ ] 11.1.2 Create `Gallformers.Accounts` context
+- [ ] 11.1.3 Create admin authentication plugs
+- [ ] 11.1.4 Create admin layout with navigation
+- [ ] 11.1.5 Create `AdminDashboardLive`
+
+### 11.2 Species Admin
+- [ ] 11.2.1 Create `Admin.SpeciesLive.Index` with listing and search
+- [ ] 11.2.2 Create `Admin.SpeciesLive.Form` for create/edit
+- [ ] 11.2.3 Implement changeset validation with error display
+- [ ] 11.2.4 Create alias/synonym editor (LiveView list management)
+- [ ] 11.2.5 Create host association editor
+- [ ] 11.2.6 Add PubSub broadcast on save
+
+### 11.3 Host Admin
+- [ ] 11.3.1 Create `Admin.HostLive.Index`
+- [ ] 11.3.2 Create `Admin.HostLive.Form`
+- [ ] 11.3.3 Add PubSub broadcast on save
+
+### 11.4 Taxonomy Admin
+- [ ] 11.4.1 Create `Admin.TaxonomyLive.Index`
+- [ ] 11.4.2 Create `Admin.TaxonomyLive.Form`
+- [ ] 11.4.3 Handle parent taxonomy selection
+
+### 11.5 Other Admin Pages
+- [ ] 11.5.1 Create source admin pages
+- [ ] 11.5.2 Create glossary admin pages
+- [ ] 11.5.3 Create place admin pages
+
+### 11.6 Image Management
+- [ ] 11.6.1 Create `ImageUpload` hook for drag-drop upload
+- [ ] 11.6.2 Implement S3 upload flow (presigned URLs)
+- [ ] 11.6.3 Create image reordering with LiveView
+- [ ] 11.6.4 Implement image deletion with confirmation
+
+## 12. Real-time Updates (PubSub)
+
+- [ ] 12.1 Configure PubSub in application supervision tree
+- [ ] 12.2 Create broadcast helpers in contexts
+- [ ] 12.3 Subscribe to entity updates in public LiveViews
+- [ ] 12.4 Handle `:entity_updated` messages to refresh assigns
+- [ ] 12.5 Test admin edit → public page auto-update
+
+## 13. Public API
+
+### 13.1 API Foundation
+- [ ] 13.1.1 Create API router scope with JSON pipeline
+- [ ] 13.1.2 Configure CORS for API routes
+- [ ] 13.1.3 Create API error view (JSON format per v2_old pattern)
+
+### 13.2 API Endpoints
+Port endpoints matching v2_old patterns (see `v2_old/api/internal/handlers/V1_V2_DIFFERENCES.md`):
+
+- [ ] 13.2.1 Create `GET /api/v2/species` with pagination
+- [ ] 13.2.2 Create `GET /api/v2/species/:id`
+- [ ] 13.2.3 Create `GET /api/v2/galls` with filtering
+- [ ] 13.2.4 Create `GET /api/v2/galls/:id`
+- [ ] 13.2.5 Create `GET /api/v2/hosts`
+- [ ] 13.2.6 Create `GET /api/v2/hosts/:id`
+- [ ] 13.2.7 Create `GET /api/v2/search` endpoint
+- [ ] 13.2.8 Create `GET /api/v2/filter-fields` endpoint
+
+### 13.3 API Documentation
+Follow the documentation style from `v2_old/api/`:
+- [ ] 13.3.1 Create `v2/API_REFERENCE.md` documenting:
+  - URL patterns (same as v2_old)
+  - Response structure (pagination format)
+  - Error response format
+  - Query parameters per endpoint
+- [ ] 13.3.2 Add open_api_spex for OpenAPI spec generation (optional)
+
+## 14. SEO
+
+- [ ] 14.1 Create `meta_tags` component for title, description, canonical
+- [ ] 14.2 Create `og_tags` component for Open Graph
+- [ ] 14.3 Add meta tags to all public pages
+- [ ] 14.4 Create `/sitemap.xml` route with all public URLs
+- [ ] 14.5 Create `/robots.txt` (allow public, disallow admin)
+- [ ] 14.6 Add JSON-LD structured data to species pages
+
+## 15. Markdown & Glossary
+
+- [ ] 15.1 Add earmark or mdex dependency
+- [ ] 15.2 Create `Gallformers.Markdown` module
+- [ ] 15.3 Implement glossary term auto-linking
+- [ ] 15.4 Cache compiled markdown in ETS or process state
+- [ ] 15.5 Test markdown rendering in source descriptions
+
+## 16. Testing
+
+### 16.1 Unit Tests
+- [ ] 16.1.1 Test Ecto schemas and changesets
+- [ ] 16.1.2 Test context functions
+- [ ] 16.1.3 Test markdown processing
+- [ ] 16.1.4 Test glossary linking
+
+### 16.2 LiveView Tests
+- [ ] 16.2.1 Test public page LiveViews render correctly
+- [ ] 16.2.2 Test search LiveView events
+- [ ] 16.2.3 Test ID tool filter events
+- [ ] 16.2.4 Test admin form submission
+
+### 16.3 Integration Tests
+- [ ] 16.3.1 Test full page load flows
+- [ ] 16.3.2 Test authentication flow
+- [ ] 16.3.3 Test PubSub broadcast → LiveView update
+
+### 16.4 API Tests
+- [ ] 16.4.1 Test API endpoints return correct JSON
+- [ ] 16.4.2 Test API error responses
+- [ ] 16.4.3 Test CORS headers
+
+## 17. Visual Parity Verification
+
+- [ ] 17.1 Compare home page side-by-side with v2_old
+- [ ] 17.2 Compare gall/species pages side-by-side
+- [ ] 17.3 Compare host pages side-by-side
+- [ ] 17.4 Compare family/genus pages side-by-side
+- [ ] 17.5 Compare search results side-by-side
+- [ ] 17.6 Compare ID tool side-by-side
+- [ ] 17.7 Compare admin pages side-by-side
+- [ ] 17.8 Test responsive layout at mobile/tablet/desktop breakpoints
+- [ ] 17.9 Sign-off: all pages achieve visual parity
+
+## 18. Cleanup (only after 17.9 complete)
+
+- [ ] 18.1 Remove `v2_old/` directory
+- [ ] 18.2 Update `v2/CLAUDE.md` - remove references to v2_old
+- [ ] 18.3 Update root `CLAUDE.md` - remove v2_old section
+- [ ] 18.4 Archive `adopt-templ-htmx` proposal
+- [ ] 18.5 Archive `convert-v2-to-spa` proposal
+
+## 19. Documentation Updates
+
+- [ ] 19.1 Document LiveView patterns in CLAUDE.md
+- [ ] 19.2 Document component library
+- [ ] 19.3 Document PubSub patterns for real-time
+- [ ] 19.4 Document deployment process
+- [ ] 19.5 Document local development setup
+
+## Dependencies
+
+```
+Phase 0 (Migration) - no dependencies
+Phase 1 (Foundation + CI) - depends on Phase 0
+Phase 2 (First Deploy) - depends on Phase 1
+Phase 3 (Home Page) - depends on Phases 1, 2
+Phase 4 (Schemas) - depends on Phase 3
+Phase 5 (Components) - depends on Phase 1
+Phase 6 (Public Pages) - depends on Phases 4, 5
+Phase 7-9 (Search, ID Tool, Explore) - depends on Phase 6
+Phase 10 (Range Map) - can parallel with Phases 6-9
+Phase 11 (Admin) - depends on Phase 6
+Phase 12 (PubSub) - depends on Phase 11
+Phase 13 (API) - depends on Phase 4
+Phase 14 (SEO) - depends on Phase 6
+Phase 15 (Markdown) - can parallel with Phase 6
+Phase 16 (Testing) - parallel with all phases
+Phase 17 (Visual Parity) - depends on all UI phases
+Phase 18 (Cleanup) - depends on Phase 17
+```
+
+## Parallelizable Work
+
+After Phase 2 (first deploy):
+- Ecto schemas (Phase 4)
+- Shared components (Phase 5)
+- Markdown processing (Phase 15)
+- Range map hook (Phase 10)
+
+After Phase 6 public pages:
+- Search LiveView (Phase 7)
+- ID Tool LiveView (Phase 8)
+- Admin pages (Phase 11)
+- API endpoints (Phase 13)
+- SEO (Phase 14)
+
+## Key Principles
+
+1. **Deploy early, deploy often** - Get something running in prod ASAP
+2. **One page at a time** - Build, deploy, verify visual parity, then move on
+3. **v2_old is the spec** - Reference the existing code, don't create separate docs
+4. **CI from day one** - Catch issues early
+5. **Home page first** - Proves the architecture works end-to-end
+
+## Future Enhancements (Post-Launch)
+
+- [ ] 20.1 Add LiveView streams for large lists (performance)
+- [ ] 20.2 Add offline indicator (detect WebSocket disconnect)
+- [ ] 20.3 Add rate limiting for API endpoints
+- [ ] 20.4 Add caching layer (ETS) for frequently accessed data
+- [ ] 20.5 Add metrics/telemetry for performance monitoring


### PR DESCRIPTION
## Summary
- Restructure Phoenix adoption tasks to start with code migration (v2 → v2_old)
- Move deployment to Phase 2 (deploy early, deploy often philosophy)
- Add home page as tracer bullet milestone to prove architecture
- Move CI setup early in foundation phase
- Remove separate route/API documentation tasks (v2_old code IS the spec)
- Simplify CLAUDE.md git workflow and multi-agent sections
- Add V1/V2 distinction to project overview

## Test plan
- [x] Proposal files are valid markdown
- [x] Tasks are logically ordered with correct dependencies