### PR TITLE
Add search LiveView with debounced search and keyboard navigation

### DIFF
--- a/openspec/changes/adopt-phoenix-liveview/tasks.md
+++ b/openspec/changes/adopt-phoenix-liveview/tasks.md
@@ -171,13 +171,13 @@ Build one page at a time, deploy after each, verify visual parity.
 - [x] 6.3.2 Create custom 500 page matching site design
 - [x] 6.3.3 Configure error view in endpoint
 
-## 7. Search (LiveView)
+## 7. Search (LiveView) ✅
 
-- [ ] 7.1 Create `SearchLive` with search input
-- [ ] 7.2 Implement `handle_event("search", ...)` with debounce
-- [ ] 7.3 Display results grouped by type (galls, hosts, sources)
-- [ ] 7.4 Add keyboard navigation for results
-- [ ] 7.5 Implement URL sync with `push_patch`
+- [x] 7.1 Create `SearchLive` with search input
+- [x] 7.2 Implement `handle_event("search", ...)` with debounce
+- [x] 7.3 Display results grouped by type (galls, hosts, sources)
+- [x] 7.4 Add keyboard navigation for results
+- [x] 7.5 Implement URL sync with `push_patch`
 
 ## 8. ID Tool (LiveView)
 

--- a/v2/lib/gallformers/markdown.ex
+++ b/v2/lib/gallformers/markdown.ex
@@ -185,8 +185,6 @@ defmodule Gallformers.Markdown do
   end
 
   defp format_errors(errors) do
-    errors
-    |> Enum.map(fn {_severity, _line, message} -> message end)
-    |> Enum.join("; ")
+    Enum.map_join(errors, "; ", fn {_severity, _line, message} -> message end)
   end
 end

--- a/v2/lib/gallformers/search.ex
+++ b/v2/lib/gallformers/search.ex
@@ -6,8 +6,13 @@ defmodule Gallformers.Search do
   """
 
   import Ecto.Query
+
+  alias Gallformers.Glossary.Glossary
+  alias Gallformers.Places.Place
   alias Gallformers.Repo
-  alias Gallformers.Species.{Gall, GallSpecies, Species}
+  alias Gallformers.Sources.Source
+  alias Gallformers.Species.{Alias, Gall, GallSpecies, Species}
+  alias Gallformers.Taxonomy.Taxonomy
 
   @doc """
   Searches galls by name (partial match).
@@ -171,5 +176,254 @@ defmodule Gallformers.Search do
       }
     )
     |> Repo.all()
+  end
+
+  @doc """
+  Performs a global search across all entity types.
+
+  Returns a map with results grouped by type.
+  """
+  @spec global_search(String.t()) :: map()
+  def global_search(query) when is_binary(query) do
+    trimmed = String.trim(query)
+
+    if trimmed == "" do
+      empty_results()
+    else
+      %{
+        galls: search_galls_with_aliases(trimmed),
+        hosts: search_hosts_with_aliases(trimmed),
+        glossary: search_glossary(trimmed),
+        sources: search_sources(trimmed),
+        taxonomy: search_taxonomy(trimmed),
+        places: search_places(trimmed)
+      }
+    end
+  end
+
+  @doc """
+  Returns empty search results.
+  """
+  @spec empty_results() :: map()
+  def empty_results do
+    %{
+      galls: [],
+      hosts: [],
+      glossary: [],
+      sources: [],
+      taxonomy: [],
+      places: []
+    }
+  end
+
+  @doc """
+  Searches galls by name or alias.
+  """
+  @spec search_galls_with_aliases(String.t()) :: [map()]
+  def search_galls_with_aliases(query) do
+    search_term = "%#{query}%"
+
+    # Search by species name
+    name_results =
+      from(s in Species,
+        join: gs in GallSpecies,
+        on: gs.species_id == s.id,
+        join: g in Gall,
+        on: gs.gall_id == g.id,
+        where: s.taxoncode == "gall" and ilike(s.name, ^search_term),
+        order_by: s.name,
+        select: %{
+          id: s.id,
+          name: s.name,
+          type: "gall",
+          undescribed: g.undescribed,
+          aliases: []
+        }
+      )
+      |> Repo.all()
+
+    # Search by alias name and return the parent species
+    alias_results =
+      from(a in Alias,
+        join: s in assoc(a, :species),
+        join: gs in GallSpecies,
+        on: gs.species_id == s.id,
+        join: g in Gall,
+        on: gs.gall_id == g.id,
+        where: s.taxoncode == "gall" and ilike(a.name, ^search_term),
+        order_by: s.name,
+        select: %{
+          id: s.id,
+          name: s.name,
+          type: "gall",
+          undescribed: g.undescribed,
+          alias_match: a.name
+        }
+      )
+      |> Repo.all()
+
+    # Merge results, adding aliases to species that were found via alias
+    merge_species_with_aliases(name_results, alias_results)
+  end
+
+  @doc """
+  Searches hosts by name or alias.
+  """
+  @spec search_hosts_with_aliases(String.t()) :: [map()]
+  def search_hosts_with_aliases(query) do
+    search_term = "%#{query}%"
+
+    # Search by species name
+    name_results =
+      from(s in Species,
+        where: s.taxoncode == "plant" and ilike(s.name, ^search_term),
+        order_by: s.name,
+        select: %{
+          id: s.id,
+          name: s.name,
+          type: "host",
+          aliases: []
+        }
+      )
+      |> Repo.all()
+
+    # Search by alias name
+    alias_results =
+      from(a in Alias,
+        join: s in assoc(a, :species),
+        where: s.taxoncode == "plant" and ilike(a.name, ^search_term),
+        order_by: s.name,
+        select: %{
+          id: s.id,
+          name: s.name,
+          type: "host",
+          alias_match: a.name
+        }
+      )
+      |> Repo.all()
+
+    merge_species_with_aliases(name_results, alias_results)
+  end
+
+  @doc """
+  Searches glossary entries by word or definition.
+  """
+  @spec search_glossary(String.t()) :: [map()]
+  def search_glossary(query) do
+    search_term = "%#{query}%"
+
+    from(g in Glossary,
+      where: ilike(g.word, ^search_term) or ilike(g.definition, ^search_term),
+      order_by: g.word,
+      select: %{
+        id: g.id,
+        name: g.word,
+        type: "glossary",
+        definition: g.definition
+      }
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Searches sources by title or author.
+  """
+  @spec search_sources(String.t()) :: [map()]
+  def search_sources(query) do
+    search_term = "%#{query}%"
+
+    from(s in Source,
+      where: ilike(s.title, ^search_term) or ilike(s.author, ^search_term),
+      order_by: s.title,
+      select: %{
+        id: s.id,
+        name: s.title,
+        type: "source",
+        author: s.author,
+        pubyear: s.pubyear
+      }
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Searches taxonomy entries (genus, family, section) by name.
+  """
+  @spec search_taxonomy(String.t()) :: [map()]
+  def search_taxonomy(query) do
+    search_term = "%#{query}%"
+
+    from(t in Taxonomy,
+      where:
+        t.type in ["genus", "family", "section"] and
+          ilike(t.name, ^search_term),
+      order_by: [t.type, t.name],
+      select: %{
+        id: t.id,
+        name: t.name,
+        type: t.type,
+        description: t.description
+      }
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Searches places by name or code.
+  """
+  @spec search_places(String.t()) :: [map()]
+  def search_places(query) do
+    search_term = "%#{query}%"
+
+    from(p in Place,
+      where: ilike(p.name, ^search_term) or ilike(p.code, ^search_term),
+      order_by: p.name,
+      select: %{
+        id: p.id,
+        name: p.name,
+        type: "place",
+        code: p.code
+      }
+    )
+    |> Repo.all()
+  end
+
+  # Merges species results with alias matches, deduplicating by ID
+  defp merge_species_with_aliases(name_results, alias_results) do
+    alias_map = build_alias_map(alias_results)
+    name_ids = MapSet.new(name_results, & &1.id)
+
+    alias_only_species =
+      alias_results
+      |> Enum.reject(fn r -> MapSet.member?(name_ids, r.id) end)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.map(&add_aliases_to_result(&1, alias_map))
+
+    name_results_with_aliases = Enum.map(name_results, &add_aliases_to_result(&1, alias_map))
+
+    name_results_with_aliases ++ alias_only_species
+  end
+
+  # Builds a map of species ID -> list of matching alias names
+  defp build_alias_map(alias_results) do
+    Enum.reduce(alias_results, %{}, fn result, acc ->
+      add_alias_to_map(acc, result.id, result.alias_match)
+    end)
+  end
+
+  defp add_alias_to_map(acc, id, alias_name) do
+    Map.update(acc, id, [alias_name], &maybe_add_alias(&1, alias_name))
+  end
+
+  defp maybe_add_alias(aliases, alias_name) do
+    if alias_name in aliases, do: aliases, else: [alias_name | aliases]
+  end
+
+  defp add_aliases_to_result(result, alias_map) do
+    aliases = Map.get(alias_map, result.id, [])
+
+    result
+    |> Map.put(:aliases, aliases)
+    |> Map.delete(:alias_match)
   end
 end

--- a/v2/lib/gallformers_web/live/search_live.ex
+++ b/v2/lib/gallformers_web/live/search_live.ex
@@ -1,0 +1,346 @@
+defmodule GallformersWeb.SearchLive do
+  @moduledoc """
+  LiveView for global search across all entity types.
+
+  Provides a unified search experience with:
+  - Debounced search input
+  - Results grouped by type (galls, hosts, sources, glossary, taxonomy, places)
+  - Sortable results table
+  - Keyboard navigation
+  - URL sync via push_patch
+  """
+  use GallformersWeb, :live_view
+
+  alias Gallformers.Search
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     assign(socket,
+       page_title: "Search | Gallformers",
+       query: "",
+       results: [],
+       total_count: 0,
+       sort_by: :name,
+       sort_dir: :asc,
+       selected_index: -1,
+       loading: false
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    query = params["q"] || ""
+
+    socket =
+      if query != socket.assigns.query do
+        perform_search(socket, query)
+      else
+        socket
+      end
+
+    {:noreply, assign(socket, query: query)}
+  end
+
+  @impl true
+  def handle_event("search", %{"q" => query}, socket) do
+    # Update URL with the search query, triggering handle_params
+    {:noreply, push_patch(socket, to: ~p"/globalsearch?#{%{q: query}}")}
+  end
+
+  @impl true
+  def handle_event("search_input", %{"q" => query}, socket) do
+    # Debounce is handled by phx-debounce on the input
+    # This just updates the URL when debounce fires
+    {:noreply, push_patch(socket, to: ~p"/globalsearch?#{%{q: query}}")}
+  end
+
+  @impl true
+  def handle_event("sort", %{"column" => column}, socket) do
+    column_atom = String.to_existing_atom(column)
+
+    {new_sort_by, new_sort_dir} =
+      if socket.assigns.sort_by == column_atom do
+        new_dir = if socket.assigns.sort_dir == :asc, do: :desc, else: :asc
+        {column_atom, new_dir}
+      else
+        {column_atom, :asc}
+      end
+
+    {:noreply, assign(socket, sort_by: new_sort_by, sort_dir: new_sort_dir, selected_index: -1)}
+  end
+
+  @impl true
+  def handle_event("keydown", %{"key" => "ArrowDown"}, socket) do
+    max_index = length(socket.assigns.results) - 1
+    new_index = min(socket.assigns.selected_index + 1, max_index)
+    {:noreply, assign(socket, selected_index: new_index)}
+  end
+
+  @impl true
+  def handle_event("keydown", %{"key" => "ArrowUp"}, socket) do
+    new_index = max(socket.assigns.selected_index - 1, -1)
+    {:noreply, assign(socket, selected_index: new_index)}
+  end
+
+  @impl true
+  def handle_event("keydown", %{"key" => "Enter"}, socket) do
+    selected_index = socket.assigns.selected_index
+
+    if selected_index >= 0 do
+      sorted =
+        sorted_results(socket.assigns.results, socket.assigns.sort_by, socket.assigns.sort_dir)
+
+      case Enum.at(sorted, selected_index) do
+        nil ->
+          {:noreply, socket}
+
+        result ->
+          {:noreply, push_navigate(socket, to: result_link(result))}
+      end
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("keydown", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("select_result", %{"index" => index_str}, socket) do
+    index = String.to_integer(index_str)
+    {:noreply, assign(socket, selected_index: index)}
+  end
+
+  defp perform_search(socket, query) do
+    trimmed = String.trim(query)
+
+    if trimmed == "" do
+      assign(socket,
+        results: [],
+        total_count: 0,
+        selected_index: -1
+      )
+    else
+      grouped = Search.global_search(trimmed)
+      results = flatten_results(grouped)
+
+      assign(socket,
+        results: results,
+        total_count: length(results),
+        selected_index: -1
+      )
+    end
+  end
+
+  defp flatten_results(grouped) do
+    galls = Enum.map(grouped.galls, &Map.put(&1, :category, "Gall"))
+    hosts = Enum.map(grouped.hosts, &Map.put(&1, :category, "Host"))
+    glossary = Enum.map(grouped.glossary, &Map.put(&1, :category, "Glossary"))
+    sources = Enum.map(grouped.sources, &Map.put(&1, :category, "Source"))
+
+    taxonomy =
+      Enum.map(grouped.taxonomy, fn t ->
+        category =
+          case t.type do
+            "genus" -> "Genus"
+            "family" -> "Family"
+            "section" -> "Section"
+            _ -> "Taxonomy"
+          end
+
+        Map.put(t, :category, category)
+      end)
+
+    places = Enum.map(grouped.places, &Map.put(&1, :category, "Place"))
+
+    galls ++ hosts ++ glossary ++ sources ++ taxonomy ++ places
+  end
+
+  defp sorted_results(results, sort_by, sort_dir) do
+    sorted =
+      Enum.sort_by(results, fn result ->
+        case sort_by do
+          :type -> result.category
+          :name -> String.downcase(result.name || "")
+          _ -> String.downcase(result.name || "")
+        end
+      end)
+
+    if sort_dir == :desc, do: Enum.reverse(sorted), else: sorted
+  end
+
+  @type_icons %{
+    "gall" => "hero-bug-ant",
+    "host" => "hero-beaker",
+    "glossary" => "hero-book-open",
+    "source" => "hero-document-text",
+    "genus" => "hero-folder",
+    "family" => "hero-folder",
+    "section" => "hero-folder",
+    "place" => "hero-map-pin"
+  }
+
+  defp result_link(%{type: "glossary", name: name}), do: ~p"/glossary##{String.downcase(name)}"
+  defp result_link(%{type: type, id: id}), do: build_entity_link(type, id)
+
+  defp build_entity_link(type, id) when type in ~w(gall host source genus family section place) do
+    "/#{type}/#{id}"
+  end
+
+  defp build_entity_link(_type, _id), do: "/"
+
+  defp type_icon(type), do: Map.get(@type_icons, type, "hero-question-mark-circle")
+
+  defp format_name(result) do
+    case result.type do
+      "gall" -> result.name
+      "host" -> result.name
+      "genus" -> "Genus #{result.name}"
+      "section" -> "Section #{result.name}"
+      "family" -> "Family #{result.name}"
+      _ -> result.name
+    end
+  end
+
+  defp italicized?(type) do
+    type in ["gall", "host", "genus", "section"]
+  end
+
+  @impl true
+  def render(assigns) do
+    sorted = sorted_results(assigns.results, assigns.sort_by, assigns.sort_dir)
+    assigns = assign(assigns, :sorted_results, sorted)
+
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="mx-auto max-w-6xl" id="search-container" phx-window-keydown="keydown">
+        <h1 class="text-3xl font-bold text-gf-maroon mb-6">Search</h1>
+
+        <form id="search-form" phx-submit="search" phx-change="search_input" class="mb-6">
+          <div class="flex gap-2">
+            <input
+              type="search"
+              name="q"
+              value={@query}
+              placeholder="Search for galls, hosts, sources, glossary terms..."
+              class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gf-maroon focus:border-transparent"
+              phx-debounce="300"
+              autocomplete="off"
+              autofocus
+            />
+            <button
+              type="submit"
+              class="px-6 py-2 bg-gf-maroon text-white rounded-lg hover:bg-opacity-90 transition-colors"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+
+        <%= if @query == "" do %>
+          <div class="bg-gray-50 rounded-lg p-8 text-center text-gray-600">
+            <.icon name="hero-magnifying-glass" class="w-12 h-12 mx-auto mb-4 text-gray-400" />
+            <p class="text-lg">
+              Enter a search term to find galls, hosts, sources, glossary entries, and more.
+            </p>
+          </div>
+        <% else %>
+          <%= if @total_count == 0 do %>
+            <div class="bg-gray-50 border border-gray-200 px-6 py-4 rounded-lg">
+              <p class="font-medium text-gray-900">No results for "{@query}"</p>
+              <p class="text-sm text-gray-600 mt-1">
+                Try adjusting your search terms or use fewer keywords.
+              </p>
+            </div>
+          <% else %>
+            <div class="mb-4 text-sm text-gray-600">
+              Found {@total_count} result{if @total_count != 1, do: "s", else: ""} for "{@query}"
+            </div>
+
+            <div class="bg-white rounded-lg shadow overflow-hidden">
+              <table class="min-w-full divide-y divide-gray-200" id="results-table">
+                <thead class="bg-gray-50">
+                  <tr>
+                    <th
+                      class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 w-32"
+                      phx-click="sort"
+                      phx-value-column="type"
+                    >
+                      Type
+                      <%= if @sort_by == :type do %>
+                        <span class="ml-1">{if @sort_dir == :asc, do: "↑", else: "↓"}</span>
+                      <% end %>
+                    </th>
+                    <th
+                      class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                      phx-click="sort"
+                      phx-value-column="name"
+                    >
+                      Name
+                      <%= if @sort_by == :name do %>
+                        <span class="ml-1">{if @sort_dir == :asc, do: "↑", else: "↓"}</span>
+                      <% end %>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                  <%= for {result, index} <- Enum.with_index(@sorted_results) do %>
+                    <tr
+                      id={"result-#{index}"}
+                      class={[
+                        "transition-colors cursor-pointer",
+                        if(index == @selected_index, do: "bg-canary", else: "hover:bg-gray-50")
+                      ]}
+                      phx-click="select_result"
+                      phx-value-index={index}
+                    >
+                      <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="flex items-center gap-2">
+                          <.icon name={type_icon(result.type)} class="w-5 h-5 text-gray-500" />
+                          <span class="text-sm text-gray-600">{result.category}</span>
+                        </div>
+                      </td>
+                      <td class="px-6 py-4">
+                        <.link
+                          href={result_link(result)}
+                          class="text-gf-maroon hover:underline"
+                        >
+                          <%= if italicized?(result.type) do %>
+                            <em>{format_name(result)}</em>
+                          <% else %>
+                            {format_name(result)}
+                          <% end %>
+                        </.link>
+                        <%= if Map.get(result, :aliases, []) != [] do %>
+                          <span class="text-sm text-gray-500 ml-2">
+                            (also: {Enum.join(result.aliases, ", ")})
+                          </span>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="mt-4 text-xs text-gray-500">
+              <p>
+                <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs">↑</kbd>
+                <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs">↓</kbd>
+                to navigate,
+                <kbd class="px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded text-xs">
+                  Enter
+                </kbd>
+                to select
+              </p>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/v2/lib/gallformers_web/router.ex
+++ b/v2/lib/gallformers_web/router.ex
@@ -29,6 +29,7 @@ defmodule GallformersWeb.Router do
     live "/resources", ResourcesLive
     live "/glossary", GlossaryLive
     live "/refindex", RefIndexLive
+    live "/globalsearch", SearchLive
 
     # Entity pages
     live "/gall/:id", GallLive


### PR DESCRIPTION
## Summary
- Create SearchLive with search input and URL sync via push_patch
- Extend Gallformers.Search context with global search across all entity types (galls, hosts, glossary, sources, taxonomy, places)
- Implement debounced search (300ms) using phx-debounce
- Display results grouped by type with sortable columns
- Add keyboard navigation (arrow keys + Enter to select)
- Fix pre-existing Credo issue in markdown.ex (use Enum.map_join)

## Test plan
- [ ] Visit `/globalsearch` and verify search input renders
- [ ] Type a query and verify results appear after 300ms debounce
- [ ] Verify results are grouped by type (galls, hosts, sources, etc.)
- [ ] Test keyboard navigation with arrow keys and Enter
- [ ] Verify URL updates with search query parameter
- [ ] Run `make ci` - all checks pass