### PR TITLE
Rename User struct to Auth0User

### DIFF
--- a/v2/lib/gallformers/accounts.ex
+++ b/v2/lib/gallformers/accounts.ex
@@ -11,14 +11,14 @@ defmodule Gallformers.Accounts do
   - `superadmin`: Full access including dangerous operations
   """
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
 
   @doc """
   Fetches the current user from the session.
 
   Returns nil if no user is logged in.
   """
-  @spec get_user_from_session(Plug.Conn.t() | map()) :: User.t() | nil
+  @spec get_user_from_session(Plug.Conn.t() | map()) :: Auth0User.t() | nil
   def get_user_from_session(%Plug.Conn{} = conn) do
     Plug.Conn.get_session(conn, :current_user)
   end
@@ -30,8 +30,8 @@ defmodule Gallformers.Accounts do
   @doc """
   Stores the user in the session after successful authentication.
   """
-  @spec put_user_in_session(Plug.Conn.t(), User.t()) :: Plug.Conn.t()
-  def put_user_in_session(conn, %User{} = user) do
+  @spec put_user_in_session(Plug.Conn.t(), Auth0User.t()) :: Plug.Conn.t()
+  def put_user_in_session(conn, %Auth0User{} = user) do
     conn
     |> Plug.Conn.put_session(:current_user, user)
     |> Plug.Conn.configure_session(renew: true)
@@ -48,24 +48,24 @@ defmodule Gallformers.Accounts do
   @doc """
   Creates a User struct from an Ueberauth authentication response.
   """
-  @spec user_from_auth(Ueberauth.Auth.t()) :: User.t()
+  @spec user_from_auth(Ueberauth.Auth.t()) :: Auth0User.t()
   def user_from_auth(%Ueberauth.Auth{} = auth) do
-    User.from_auth(auth)
+    Auth0User.from_auth(auth)
   end
 
   @doc """
   Returns true if the user is an admin (or superadmin).
   """
-  @spec admin?(User.t() | nil) :: boolean()
+  @spec admin?(Auth0User.t() | nil) :: boolean()
   def admin?(nil), do: false
-  def admin?(%User{} = user), do: User.admin?(user)
+  def admin?(%Auth0User{} = user), do: Auth0User.admin?(user)
 
   @doc """
   Returns true if the user is a superadmin.
   """
-  @spec superadmin?(User.t() | nil) :: boolean()
+  @spec superadmin?(Auth0User.t() | nil) :: boolean()
   def superadmin?(nil), do: false
-  def superadmin?(%User{} = user), do: User.superadmin?(user)
+  def superadmin?(%Auth0User{} = user), do: Auth0User.superadmin?(user)
 
   @doc """
   Returns the Auth0 logout URL.

--- a/v2/lib/gallformers/accounts/auth0_user.ex
+++ b/v2/lib/gallformers/accounts/auth0_user.ex
@@ -1,4 +1,4 @@
-defmodule Gallformers.Accounts.User do
+defmodule Gallformers.Accounts.Auth0User do
   @moduledoc """
   Represents an authenticated user from Auth0.
 
@@ -18,13 +18,13 @@ defmodule Gallformers.Accounts.User do
   defstruct [:id, :email, :name, :nickname, :picture, roles: []]
 
   @doc """
-  Creates a User struct from Ueberauth Auth0 response.
+  Creates an Auth0User struct from Ueberauth Auth0 response.
 
   ## Examples
 
       iex> auth = %Ueberauth.Auth{uid: "auth0|123", info: %{email: "test@example.com"}}
-      iex> User.from_auth(auth)
-      %User{id: "auth0|123", email: "test@example.com", ...}
+      iex> Auth0User.from_auth(auth)
+      %Auth0User{id: "auth0|123", email: "test@example.com", ...}
   """
   @spec from_auth(Ueberauth.Auth.t()) :: t()
   def from_auth(%Ueberauth.Auth{} = auth) do

--- a/v2/lib/gallformers_web/components/layouts.ex
+++ b/v2/lib/gallformers_web/components/layouts.ex
@@ -266,7 +266,7 @@ defmodule GallformersWeb.Layouts do
               <img class="h-6 w-6 rounded-full" src={@current_user.picture} alt="" />
             <% end %>
             <span class="text-base font-medium text-gf-maroon">
-              {Gallformers.Accounts.User.display_name(@current_user)}
+              {Gallformers.Accounts.Auth0User.display_name(@current_user)}
             </span>
             <a
               href="/auth/logout"
@@ -349,7 +349,7 @@ defmodule GallformersWeb.Layouts do
               <img class="h-6 w-6 rounded-full" src={@current_user.picture} alt="" />
             <% end %>
             <span class="text-base font-medium text-gf-maroon">
-              {Gallformers.Accounts.User.display_name(@current_user)}
+              {Gallformers.Accounts.Auth0User.display_name(@current_user)}
             </span>
           </div>
           <a

--- a/v2/lib/gallformers_web/controllers/auth_controller.ex
+++ b/v2/lib/gallformers_web/controllers/auth_controller.ex
@@ -10,7 +10,7 @@ defmodule GallformersWeb.AuthController do
   plug Ueberauth
 
   alias Gallformers.Accounts
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
 
   @doc """
   Handles the OAuth request phase. This action exists to allow the
@@ -49,7 +49,7 @@ defmodule GallformersWeb.AuthController do
 
     conn
     |> Accounts.put_user_in_session(user)
-    |> put_flash(:info, "Welcome back, #{User.display_name(user)}!")
+    |> put_flash(:info, "Welcome back, #{Auth0User.display_name(user)}!")
     |> redirect(to: get_return_to(conn))
   end
 

--- a/v2/lib/gallformers_web/live/admin/article_admin_live.ex
+++ b/v2/lib/gallformers_web/live/admin/article_admin_live.ex
@@ -14,7 +14,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
   # Import the discard_confirm_modal component
   import GallformersWeb.Admin.FormHelpers, only: [discard_confirm_modal: 1]
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
   alias Gallformers.Articles
   alias Gallformers.Articles.Article
   alias Gallformers.Images
@@ -485,7 +485,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
   @impl true
   def handle_event("new_article", _params, socket) do
     # Pre-populate author from logged in user
-    author = User.display_name(socket.assigns.current_user)
+    author = Auth0User.display_name(socket.assigns.current_user)
 
     article = %Article{author: author}
     changeset = Articles.change_article(article, %{author: author})

--- a/v2/test/gallformers_web/integration_test.exs
+++ b/v2/test/gallformers_web/integration_test.exs
@@ -5,7 +5,7 @@ defmodule GallformersWeb.IntegrationTest do
   use GallformersWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
   alias Gallformers.{Hosts, Species}
 
   describe "Public page load flows" do
@@ -163,7 +163,7 @@ defmodule GallformersWeb.IntegrationTest do
     end
 
     test "authenticated user can access admin", %{conn: conn} do
-      user = %User{
+      user = %Auth0User{
         id: "test-user-id",
         email: "admin@test.com",
         name: "Test Admin",

--- a/v2/test/gallformers_web/live/admin/gall_live/form_test.exs
+++ b/v2/test/gallformers_web/live/admin/gall_live/form_test.exs
@@ -15,13 +15,13 @@ defmodule GallformersWeb.Admin.GallLive.FormTest do
   use GallformersWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
   alias Gallformers.Hosts
   alias Gallformers.Species
 
   # Helper to set up admin session
   defp setup_admin_session(conn) do
-    user = %User{
+    user = %Auth0User{
       id: "test-admin-id",
       email: "admin@test.com",
       name: "Test Admin",

--- a/v2/test/gallformers_web/live/admin/gallhost_live_test.exs
+++ b/v2/test/gallformers_web/live/admin/gallhost_live_test.exs
@@ -12,13 +12,13 @@ defmodule GallformersWeb.Admin.GallhostLiveTest do
   use GallformersWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
   alias Gallformers.Hosts
   alias Gallformers.Species
 
   # Helper to set up admin session
   defp setup_admin_session(conn) do
-    user = %User{
+    user = %Auth0User{
       id: "test-admin-id",
       email: "admin@test.com",
       name: "Test Admin",

--- a/v2/test/gallformers_web/live/admin/host_live/form_test.exs
+++ b/v2/test/gallformers_web/live/admin/host_live/form_test.exs
@@ -13,12 +13,12 @@ defmodule GallformersWeb.Admin.HostLive.FormTest do
   use GallformersWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
   alias Gallformers.Hosts
 
   # Helper to set up admin session
   defp setup_admin_session(conn) do
-    user = %User{
+    user = %Auth0User{
       id: "test-admin-id",
       email: "admin@test.com",
       name: "Test Admin",

--- a/v2/test/gallformers_web/live/admin_dashboard_live_test.exs
+++ b/v2/test/gallformers_web/live/admin_dashboard_live_test.exs
@@ -5,12 +5,12 @@ defmodule GallformersWeb.AdminDashboardLiveTest do
   use GallformersWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
-  alias Gallformers.Accounts.User
+  alias Gallformers.Accounts.Auth0User
 
   describe "Admin dashboard" do
     setup %{conn: conn} do
       # Create a mock user session for admin access (must be a User struct)
-      user = %User{
+      user = %Auth0User{
         id: "test-user-id",
         email: "admin@test.com",
         name: "Test Admin",
@@ -70,7 +70,7 @@ defmodule GallformersWeb.AdminDashboardLiveTest do
 
   describe "Admin dashboard stats" do
     setup %{conn: conn} do
-      user = %User{
+      user = %Auth0User{
         id: "test-user-id",
         email: "admin@test.com",
         name: "Test Admin",
@@ -114,7 +114,7 @@ defmodule GallformersWeb.AdminDashboardLiveTest do
 
   describe "Admin dashboard quick actions" do
     setup %{conn: conn} do
-      user = %User{
+      user = %Auth0User{
         id: "test-user-id",
         email: "admin@test.com",
         name: "Test Admin",


### PR DESCRIPTION
## Summary
- Renames `Gallformers.Accounts.User` to `Gallformers.Accounts.Auth0User`
- Updates all references throughout the v2 codebase (lib and test files)
- The existing struct holds Auth0 session data, not database records

This makes room for a new database-backed User schema that will store user profiles and preferences.

Closes gallformers-de6j