### PR TITLE
Document private S3 bucket for full backups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,11 +401,27 @@ The site should be:
 ## External Services
 
 - **Domain**: gallformers.org, gallformers.com (Namecheap)
-- **Hosting**: Digital Ocean Droplet
+- **Hosting**: Digital Ocean Droplet (v1), Fly.io (v2)
 - **Images**: AWS S3 (personal account)
 - **Auth**: Auth0
 - **Monitoring**: AWS Lambda + CloudWatch + Slack
 - **SSL**: Let's Encrypt (auto-renewal)
+
+## AWS Infrastructure
+
+**Region**: `us-east-1` (N. Virginia) - All AWS resources use this region to match Fly.io's `iad` datacenter for low latency.
+
+**S3 Buckets:**
+| Bucket | Access | Purpose |
+|--------|--------|---------|
+| `gallformers` | Public | Production images |
+| `gallformers-backups` | Mixed | Litestream backups (private) + sanitized DB snapshots (public prefix) |
+| `gallformers-full-backups` | Private | Full unsanitized database backups (contains PII) |
+
+**IAM Users:**
+- `litestream-gallformers` - Used by Fly.io and GitHub Actions for database backups
+
+See `v2/docs/backup-setup.md` for detailed S3/IAM configuration.
 
 ## Getting Help
 

--- a/v2/docs/aws-private-backup-bucket.md
+++ b/v2/docs/aws-private-backup-bucket.md
@@ -1,0 +1,77 @@
+# Private S3 Bucket for Full Database Backups
+
+This document describes the private S3 bucket used for storing full (unsanitized) database backups.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Bucket name | `gallformers-full-backups` |
+| Region | `us-east-1` |
+| Access | Private (IAM only) |
+| Versioning | Enabled |
+| Created | 2026-01-18 |
+
+## Purpose
+
+This bucket stores **full database backups containing PII** (user emails, etc.). These backups are NOT sanitized and should never be made public.
+
+Use cases:
+- Disaster recovery requiring user data
+- Legal/compliance data retention
+- Point-in-time recovery with full user context
+
+## Access Control
+
+**IAM Policy**: `LitestreamGallformersBackup` (shared with `gallformers-backups` bucket)
+
+**IAM User**: `litestream-gallformers`
+
+The same credentials used for Litestream backups have access to this bucket. No additional secrets are needed.
+
+## Comparison with Other Buckets
+
+| Bucket | Access | Contains PII | Use |
+|--------|--------|--------------|-----|
+| `gallformers` | Public | No | Production images |
+| `gallformers-backups` | Mixed | No | Litestream (private) + sanitized snapshots (public) |
+| `gallformers-full-backups` | Private | **Yes** | Full unsanitized backups |
+
+## GitHub Actions Usage
+
+The daily backup workflow can optionally upload a full backup here before sanitization:
+
+```yaml
+- name: Upload full backup (private)
+  env:
+    AWS_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}
+    AWS_DEFAULT_REGION: us-east-1
+  run: |
+    aws s3 cp gallformers.sqlite s3://gallformers-full-backups/$(date +%Y-%m-%d)/gallformers.sqlite
+```
+
+## Lifecycle Policy (Optional)
+
+To control costs, consider adding a lifecycle rule to expire old backups:
+
+```bash
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket gallformers-full-backups \
+  --lifecycle-configuration '{
+    "Rules": [{
+      "ID": "ExpireOldBackups",
+      "Status": "Enabled",
+      "Filter": {"Prefix": ""},
+      "Expiration": {"Days": 90},
+      "NoncurrentVersionExpiration": {"NoncurrentDays": 30}
+    }]
+  }'
+```
+
+## Security Notes
+
+- Never make this bucket public
+- Never add a bucket policy allowing public access
+- Audit access periodically via CloudTrail
+- Consider enabling S3 Object Lock for compliance requirements


### PR DESCRIPTION
## Summary
- Create `gallformers-full-backups` private S3 bucket in us-east-1 for unsanitized database backups
- Add AWS Infrastructure section to CLAUDE.md documenting all S3 buckets and the standard region
- Document the new bucket configuration in v2/docs/aws-private-backup-bucket.md
- Update IAM policy `LitestreamGallformersBackup` to include access to the new bucket

## Bucket Details
| Property | Value |
|----------|-------|
| Name | `gallformers-full-backups` |
| Region | `us-east-1` |
| Access | Private (IAM only) |
| Versioning | Enabled |

## Test plan
- [x] Bucket created and verified via AWS CLI
- [x] Versioning enabled
- [x] IAM policy updated to grant access
- [x] mix format, compile, credo, test all pass

Closes gallformers-xkar