### PR TITLE
Add user table migration and Ecto schema

### DIFF
--- a/v2/lib/gallformers/accounts.ex
+++ b/v2/lib/gallformers/accounts.ex
@@ -2,16 +2,20 @@ defmodule Gallformers.Accounts do
   @moduledoc """
   The Accounts context handles user authentication and authorization.
 
-  Authentication is handled by Auth0 via Ueberauth. Users are not stored in the
-  local database - instead, we rely on Auth0 for user management and extract
-  user information from the authentication response.
+  Authentication is handled by Auth0 via Ueberauth. User profiles are stored in
+  the local database for preferences and public display (like the About page),
+  but Auth0 remains the source of truth for authentication and authorization.
 
   Authorization is role-based, with roles provided by Auth0 custom claims:
   - `admin`: Can access admin features and modify data
   - `superadmin`: Full access including dangerous operations
   """
 
+  import Ecto.Query
+
   alias Gallformers.Accounts.Auth0User
+  alias Gallformers.Accounts.User
+  alias Gallformers.Repo
 
   @doc """
   Fetches the current user from the session.
@@ -83,5 +87,97 @@ defmodule Gallformers.Accounts do
         "client_id" => client_id,
         "returnTo" => return_to
       })
+  end
+
+  # ============================================================================
+  # User Profile Functions (Database-backed)
+  # ============================================================================
+
+  @doc """
+  Gets a user profile by ID.
+
+  Returns `nil` if the user does not exist.
+
+  ## Examples
+
+      iex> get_user(123)
+      %User{}
+
+      iex> get_user(999)
+      nil
+  """
+  @spec get_user(integer()) :: User.t() | nil
+  def get_user(id), do: Repo.get(User, id)
+
+  @doc """
+  Gets a user profile by Auth0 ID.
+
+  Returns `nil` if no user with that Auth0 ID exists.
+
+  ## Examples
+
+      iex> get_user_by_auth0_id("auth0|123")
+      %User{}
+
+      iex> get_user_by_auth0_id("auth0|unknown")
+      nil
+  """
+  @spec get_user_by_auth0_id(String.t()) :: User.t() | nil
+  def get_user_by_auth0_id(auth0_id) do
+    Repo.get_by(User, auth0_id: auth0_id)
+  end
+
+  @doc """
+  Creates a new user profile.
+
+  ## Examples
+
+      iex> create_user(%{auth0_id: "auth0|123", display_name: "Alice"})
+      {:ok, %User{}}
+
+      iex> create_user(%{})
+      {:error, %Ecto.Changeset{}}
+  """
+  @spec create_user(map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def create_user(attrs) do
+    %User{}
+    |> User.create_changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates an existing user profile.
+
+  ## Examples
+
+      iex> update_user(user, %{display_name: "New Name"})
+      {:ok, %User{}}
+
+      iex> update_user(user, %{inaturalist_url: "not-a-url"})
+      {:error, %Ecto.Changeset{}}
+  """
+  @spec update_user(User.t(), map()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Lists users who have opted in to appear on the About page.
+
+  Returns users ordered by display name (nulls last).
+
+  ## Examples
+
+      iex> list_users_for_about_page()
+      [%User{show_on_about: true}, ...]
+  """
+  @spec list_users_for_about_page() :: [User.t()]
+  def list_users_for_about_page do
+    User
+    |> where([u], u.show_on_about == true)
+    |> order_by([u], fragment("COALESCE(?, ?) COLLATE NOCASE", u.display_name, u.nickname))
+    |> Repo.all()
   end
 end

--- a/v2/lib/gallformers/accounts/user.ex
+++ b/v2/lib/gallformers/accounts/user.ex
@@ -1,0 +1,105 @@
+defmodule Gallformers.Accounts.User do
+  @moduledoc """
+  Database-backed user profile schema.
+
+  Stores user preferences and profile information for display on the site.
+  Authentication and authorization are handled by Auth0 - this schema only
+  stores user-editable profile data.
+
+  ## Fields
+
+  - `auth0_id` - Unique identifier from Auth0 (e.g., "auth0|12345")
+  - `display_name` - User's chosen display name (from Auth0, editable)
+  - `nickname` - Fallback display name from Auth0
+  - `inaturalist_url` - Link to user's iNaturalist profile
+  - `social_url` - Link to social media (Twitter, Mastodon, etc.)
+  - `personal_url` - Link to personal website
+  - `show_on_about` - Whether to display user on the About page
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{
+          id: integer() | nil,
+          auth0_id: String.t(),
+          display_name: String.t() | nil,
+          nickname: String.t() | nil,
+          inaturalist_url: String.t() | nil,
+          social_url: String.t() | nil,
+          personal_url: String.t() | nil,
+          show_on_about: boolean(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "users" do
+    field :auth0_id, :string
+    field :display_name, :string
+    field :nickname, :string
+    field :inaturalist_url, :string
+    field :social_url, :string
+    field :personal_url, :string
+    field :show_on_about, :boolean, default: false
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @doc """
+  Changeset for creating a new user profile.
+
+  Requires `auth0_id` to be present.
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(user, attrs) do
+    user
+    |> cast(attrs, [
+      :auth0_id,
+      :display_name,
+      :nickname,
+      :inaturalist_url,
+      :social_url,
+      :personal_url,
+      :show_on_about
+    ])
+    |> validate_required([:auth0_id])
+    |> unique_constraint(:auth0_id)
+    |> validate_url(:inaturalist_url)
+    |> validate_url(:social_url)
+    |> validate_url(:personal_url)
+  end
+
+  @doc """
+  Changeset for updating an existing user profile.
+
+  Does not allow changing the `auth0_id`.
+  """
+  @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
+  def update_changeset(user, attrs) do
+    user
+    |> cast(attrs, [
+      :display_name,
+      :nickname,
+      :inaturalist_url,
+      :social_url,
+      :personal_url,
+      :show_on_about
+    ])
+    |> validate_url(:inaturalist_url)
+    |> validate_url(:social_url)
+    |> validate_url(:personal_url)
+  end
+
+  defp validate_url(changeset, field) do
+    validate_change(changeset, field, fn _, value ->
+      case URI.parse(value) do
+        %URI{scheme: scheme, host: host}
+        when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+          []
+
+        _ ->
+          [{field, "must be a valid URL"}]
+      end
+    end)
+  end
+end

--- a/v2/priv/repo/migrations/20260118173150_create_users_table.exs
+++ b/v2/priv/repo/migrations/20260118173150_create_users_table.exs
@@ -1,0 +1,19 @@
+defmodule Gallformers.Repo.Migrations.CreateUsersTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:users) do
+      add :auth0_id, :text, null: false
+      add :display_name, :text
+      add :nickname, :text
+      add :inaturalist_url, :text
+      add :social_url, :text
+      add :personal_url, :text
+      add :show_on_about, :boolean, default: false, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:users, [:auth0_id])
+  end
+end


### PR DESCRIPTION
Creates the database migration and Ecto schema for user profiles.

Table includes:
- auth0_id (unique identifier from Auth0)
- display_name and nickname
- Profile URLs (iNaturalist, social, personal)
- show_on_about flag for About page opt-in

Context functions added to Accounts module:
- `get_user/1` - Get user by ID
- `get_user_by_auth0_id/1` - Get user by Auth0 ID
- `create_user/1` - Create a new user profile
- `update_user/2` - Update an existing user profile
- `list_users_for_about_page/0` - List users who opted in to the About page

Closes gallformers-vcmf