### PR TITLE
Create/update user records on Auth0 login

### DIFF
--- a/v2/lib/gallformers/accounts.ex
+++ b/v2/lib/gallformers/accounts.ex
@@ -58,6 +58,53 @@ defmodule Gallformers.Accounts do
   end
 
   @doc """
+  Syncs user profile data from Auth0 to the local database.
+
+  On successful login:
+  - If the user doesn't exist, creates a new profile with data from Auth0
+  - If the user exists, updates the nickname and conditionally updates display_name
+
+  The display_name is only updated if the user hasn't customized it (i.e., if it
+  currently matches the old nickname or is nil).
+
+  ## Examples
+
+      iex> sync_user_from_auth0(%Auth0User{id: "auth0|123", name: "Alice", nickname: "alice"})
+      {:ok, %User{}}
+  """
+  @spec sync_user_from_auth0(Auth0User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def sync_user_from_auth0(%Auth0User{} = auth0_user) do
+    case get_user_by_auth0_id(auth0_user.id) do
+      nil ->
+        create_user(%{
+          auth0_id: auth0_user.id,
+          display_name: auth0_user.name,
+          nickname: auth0_user.nickname,
+          show_on_about: false
+        })
+
+      %User{} = user ->
+        attrs = build_update_attrs(user, auth0_user)
+        update_user(user, attrs)
+    end
+  end
+
+  # Build the attributes to update for an existing user.
+  # Always syncs nickname from Auth0.
+  # Only updates display_name if the user hasn't customized it.
+  defp build_update_attrs(%User{} = user, %Auth0User{} = auth0_user) do
+    attrs = %{nickname: auth0_user.nickname}
+
+    # Only update display_name if user hasn't customized it
+    # (i.e., it matches the old nickname or is nil)
+    if user.display_name == user.nickname or is_nil(user.display_name) do
+      Map.put(attrs, :display_name, auth0_user.name)
+    else
+      attrs
+    end
+  end
+
+  @doc """
   Returns true if the user is an admin (or superadmin).
   """
   @spec admin?(Auth0User.t() | nil) :: boolean()

--- a/v2/lib/gallformers_web/controllers/auth_controller.ex
+++ b/v2/lib/gallformers_web/controllers/auth_controller.ex
@@ -41,16 +41,31 @@ defmodule GallformersWeb.AuthController do
   @doc """
   Handles the OAuth callback from Auth0.
 
-  On success, creates a user from the auth response and stores it in the session.
+  On success, creates a user from the auth response, syncs the user profile
+  to the database, and stores the Auth0 user in the session.
   On failure, redirects to the home page with an error message.
   """
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
-    user = Accounts.user_from_auth(auth)
+    auth0_user = Accounts.user_from_auth(auth)
 
-    conn
-    |> Accounts.put_user_in_session(user)
-    |> put_flash(:info, "Welcome back, #{Auth0User.display_name(user)}!")
-    |> redirect(to: get_return_to(conn))
+    # Sync user profile to database (create or update)
+    case Accounts.sync_user_from_auth0(auth0_user) do
+      {:ok, _user} ->
+        conn
+        |> Accounts.put_user_in_session(auth0_user)
+        |> put_flash(:info, "Welcome back, #{Auth0User.display_name(auth0_user)}!")
+        |> redirect(to: get_return_to(conn))
+
+      {:error, changeset} ->
+        require Logger
+        Logger.error("Failed to sync user profile: #{inspect(changeset.errors)}")
+
+        # Still allow login even if profile sync fails
+        conn
+        |> Accounts.put_user_in_session(auth0_user)
+        |> put_flash(:info, "Welcome back, #{Auth0User.display_name(auth0_user)}!")
+        |> redirect(to: get_return_to(conn))
+    end
   end
 
   def callback(%{assigns: %{ueberauth_failure: failure}} = conn, _params) do


### PR DESCRIPTION
## Summary
Modifies the Auth0 login callback to sync user records to the database.

On login:
- Creates new user if first login
- Updates nickname from Auth0
- Preserves user-customized display_name

## Changes
- Added `sync_user_from_auth0/1` function to `Gallformers.Accounts` that creates or updates user profiles on login
- Updated `AuthController.callback/2` to call the sync function after successful Auth0 authentication
- Errors in profile sync are logged but don't block login

Closes gallformers-jru2