### PR TITLE
Add PII sanitization to database backup workflow

### DIFF
--- a/.github/workflows/db-snapshot.yml
+++ b/.github/workflows/db-snapshot.yml
@@ -23,7 +23,33 @@ jobs:
           litestream restore -o gallformers.sqlite \
             s3://gallformers-backups/litestream
 
-      - name: Upload public snapshot
+      - name: Upload full backup (private, contains PII)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          aws s3 cp gallformers.sqlite s3://gallformers-full-backups/$(date +%Y-%m-%d)/gallformers.sqlite
+
+      - name: Sanitize user data (remove PII)
+        run: |
+          # Check if users table exists before attempting sanitization
+          TABLE_EXISTS=$(sqlite3 gallformers.sqlite "SELECT name FROM sqlite_master WHERE type='table' AND name='users';")
+          if [ -n "$TABLE_EXISTS" ]; then
+            echo "Sanitizing users table..."
+            sqlite3 gallformers.sqlite "UPDATE users SET
+              display_name = NULL,
+              nickname = NULL,
+              inaturalist_url = NULL,
+              social_url = NULL,
+              personal_url = NULL,
+              auth0_id = 'redacted-' || id;"
+            echo "Sanitization complete"
+          else
+            echo "Users table does not exist, skipping sanitization"
+          fi
+
+      - name: Upload public snapshot (sanitized)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- Uploads full backup to private S3 bucket (`gallformers-full-backups`) before sanitizing
- Sanitizes user table (removes display_name, nickname, URLs, redacts auth0_id)
- Uploads sanitized backup to public bucket

The sanitization preserves user IDs for referential integrity while removing all PII.

Closes gallformers-vk9j