### PR TITLE
Document PII handling and database backup process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,10 @@ Key tables and relationships:
 
 - **source** - Scientific references and citations
 
+- **users** - User profiles (V2 only, contains PII)
+  - Fields: auth0_id, display_name, nickname, profile URLs
+  - See [runbooks/database-backup.md](runbooks/database-backup.md) for PII handling
+
 See `prisma/schema.prisma` for complete schema details.
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -93,7 +93,34 @@ Because [yarn is a PITA](https://github.com/yarnpkg/yarn/issues/3630) you will h
 If you leave them in you will not be able to build with docker as `better-sqlite3` requires python to build and there is no python in the docker container.
 
 ### Backup Strategy
-TBD. For now manual snapshots of the block volume are all we have. All of the source is on github and the site can be re-created from scratch on a new instance from the files there. The only real back up needed is the database.
+
+The database is backed up using two complementary approaches:
+
+1. **Litestream** - Continuous replication to S3 (near real-time)
+2. **Daily snapshots** - GitHub Actions workflow creating point-in-time snapshots
+
+Daily snapshots are stored in two locations:
+- **Public** (`s3://gallformers-backups/public/`) - Sanitized, PII removed
+- **Private** (`s3://gallformers-full-backups/`) - Full backup with PII
+
+See [runbooks/database-backup.md](runbooks/database-backup.md) for complete backup and recovery documentation.
+
+### PII Handling
+
+The `users` table contains personally identifiable information:
+
+| Field | Description |
+|-------|-------------|
+| `auth0_id` | Unique identifier from Auth0 |
+| `display_name` | User's chosen display name |
+| `nickname` | Fallback name from Auth0 |
+| `inaturalist_url` | Link to iNaturalist profile |
+| `social_url` | Link to social media |
+| `personal_url` | Link to personal website |
+
+**Public database downloads are sanitized** - all PII fields are set to NULL and auth0_id is replaced with a placeholder.
+
+To request access to a full (unsanitized) backup for legitimate research or administrative purposes, contact the project maintainers.
 
 ### Front-End
 The front-end is mostly static pages as we expect most of this data to not change frequently.  next.js is built on [React](https://reactjs.org/) so you will need some familiarity with that to work on the site. The look-and-feel is built with [react-bootstrap](https://react-bootstrap.github.io/). Custom components are placed in the [pages/components](pages/components) directory and global layout components in [pages/layouts](pages/layouts). 

--- a/runbooks/database-backup.md
+++ b/runbooks/database-backup.md
@@ -1,0 +1,122 @@
+# Database Backup Runbook
+
+This document describes the automated backup process for the Gallformers database, including PII handling and how to access backups.
+
+## Overview
+
+Gallformers uses a two-tier backup strategy:
+
+1. **Litestream** - Continuous replication to S3 (near real-time)
+2. **Daily snapshots** - GitHub Actions workflow creating point-in-time snapshots
+
+## Backup Locations
+
+| Bucket | Path | Access | Contents |
+|--------|------|--------|----------|
+| `gallformers-backups` | `/litestream/` | Private | Litestream continuous replication |
+| `gallformers-backups` | `/public/gallformers.sqlite` | Public | Daily sanitized snapshot (no PII) |
+| `gallformers-full-backups` | `/{date}/gallformers.sqlite` | Private | Daily full backup (contains PII) |
+
+All buckets are in AWS region `us-east-1`.
+
+## Daily Snapshot Workflow
+
+The GitHub Actions workflow (`.github/workflows/db-snapshot.yml`) runs daily at 6 AM UTC:
+
+1. **Restore from Litestream** - Downloads the latest database state from Litestream replication
+2. **Upload full backup** - Copies the complete database (with PII) to `gallformers-full-backups`
+3. **Sanitize user data** - Removes all personally identifiable information from the users table
+4. **Upload public snapshot** - Uploads the sanitized database to `gallformers-backups/public/`
+
+### Manual Trigger
+
+The workflow can be triggered manually from GitHub Actions if an immediate snapshot is needed.
+
+## PII Sanitization
+
+The daily snapshot sanitizes the `users` table before creating the public download. The following fields are modified:
+
+| Field | Sanitization |
+|-------|-------------|
+| `display_name` | Set to NULL |
+| `nickname` | Set to NULL |
+| `inaturalist_url` | Set to NULL |
+| `social_url` | Set to NULL |
+| `personal_url` | Set to NULL |
+| `auth0_id` | Replaced with `redacted-{id}` |
+
+The `show_on_about` flag and timestamps are preserved as they are not PII.
+
+## Downloading Backups
+
+### Public Snapshot (Sanitized)
+
+The sanitized daily snapshot is publicly accessible:
+
+```bash
+# Direct download
+curl -O https://gallformers-backups.s3.amazonaws.com/public/gallformers.sqlite
+
+# Via AWS CLI
+aws s3 cp s3://gallformers-backups/public/gallformers.sqlite ./gallformers.sqlite
+
+# Via v2 Makefile (recommended for development)
+cd v2 && make download-db
+```
+
+### Full Backup (Contains PII)
+
+Full backups require AWS credentials with access to the `gallformers-full-backups` bucket.
+
+**Who can access full backups:**
+- Project maintainers with AWS access
+- Authorized researchers (contact maintainers)
+
+**To download a full backup:**
+
+```bash
+aws s3 ls s3://gallformers-full-backups/  # List available dates
+aws s3 cp s3://gallformers-full-backups/2026-01-18/gallformers.sqlite ./gallformers.sqlite
+```
+
+## Litestream Configuration
+
+Litestream runs as a sidecar process on Fly.io, providing continuous replication:
+
+- **Replication frequency**: Near real-time (every few seconds)
+- **Retention**: Managed by Litestream generations
+- **Location**: `s3://gallformers-backups/litestream/`
+
+To restore from Litestream:
+
+```bash
+litestream restore -o gallformers.sqlite s3://gallformers-backups/litestream
+```
+
+See [database-recovery.md](database-recovery.md) for full recovery procedures.
+
+## Monitoring
+
+### Checking Snapshot Sizes
+
+Healthy snapshots should be approximately 5-6MB. Very small snapshots (~300 bytes) indicate corruption:
+
+```bash
+aws s3 ls s3://gallformers-backups/public/ --human-readable
+aws s3 ls s3://gallformers-full-backups/ --recursive --human-readable | tail -10
+```
+
+### GitHub Actions History
+
+Check the workflow run history for any failures:
+
+```bash
+gh run list --workflow=db-snapshot.yml --limit=10
+```
+
+## Related Documentation
+
+- [database-recovery.md](database-recovery.md) - Recovery procedures for corrupted databases
+- [deploy.md](deploy.md) - Deployment procedures
+- Root CLAUDE.md - AWS infrastructure overview
+- v2/docs/backup-setup.md - S3/IAM configuration details

--- a/v2/CLAUDE.md
+++ b/v2/CLAUDE.md
@@ -74,6 +74,25 @@ cp ../prisma/gallformers.sqlite priv/gallformers.sqlite
 
 The database must exist at `priv/gallformers.sqlite` before running the app.
 
+### Users Table
+
+The `users` table stores user profile information (managed by `Gallformers.Accounts.User`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Primary key |
+| `auth0_id` | text | Unique Auth0 identifier (e.g., "auth0\|12345") |
+| `display_name` | text | User's chosen display name |
+| `nickname` | text | Fallback name from Auth0 |
+| `inaturalist_url` | text | Link to iNaturalist profile |
+| `social_url` | text | Link to social media |
+| `personal_url` | text | Link to personal website |
+| `show_on_about` | boolean | Display on About page |
+| `inserted_at` | datetime | Creation timestamp |
+| `updated_at` | datetime | Last update timestamp |
+
+**Note**: This table contains PII. Public database downloads have these fields sanitized. See [runbooks/database-backup.md](/runbooks/database-backup.md) for details.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- Add comprehensive runbook for database backups (`runbooks/database-backup.md`)
- Document PII sanitization process in README.md
- Add users table schema documentation to v2/CLAUDE.md
- Add users table reference in root CLAUDE.md

## Changes

**New files:**
- `runbooks/database-backup.md` - Complete documentation of backup strategy, PII sanitization, and how to access backups

**Updated files:**
- `README.md` - Added Backup Strategy and PII Handling sections
- `v2/CLAUDE.md` - Added users table schema with field descriptions
- `CLAUDE.md` - Added users table to Database Schema Overview

## Test plan
- [x] Documentation only - no code changes
- [x] All pre-commit checks pass (format, compile, credo, tests)

Closes gallformers-fl1h