### PR TITLE
gallformers-rj2c: Fix checkbox hidden input

### DIFF
--- a/v2/lib/gallformers_web/live/admin/article_admin_live.ex
+++ b/v2/lib/gallformers_web/live/admin/article_admin_live.ex
@@ -326,6 +326,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
                 <p class="mt-1 text-xs text-gray-500">Comma-separated list of tags</p>
               </div>
               <div class="flex items-center gap-2">
+                <input type="hidden" name={@form[:is_published].name} value="false" />
                 <input
                   type="checkbox"
                   name={@form[:is_published].name}

--- a/v2/lib/gallformers_web/live/admin/gall_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/gall_live/form.ex
@@ -935,9 +935,11 @@ defmodule GallformersWeb.Admin.GallLive.Form do
           <%!-- Checkboxes --%>
           <div class="space-y-2 mb-4">
             <label class="flex items-start gap-2 cursor-pointer">
+              <input type="hidden" name="species[datacomplete]" value="false" />
               <input
                 type="checkbox"
                 name="species[datacomplete]"
+                value="true"
                 checked={@form[:datacomplete].value}
                 class="mt-0.5 rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
               />

--- a/v2/lib/gallformers_web/live/admin/host_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/host_live/form.ex
@@ -587,9 +587,11 @@ defmodule GallformersWeb.Admin.HostLive.Form do
           <%!-- Data Complete checkbox --%>
           <div class="space-y-2 mb-4">
             <label class="flex items-start gap-2 cursor-pointer">
+              <input type="hidden" name="species[datacomplete]" value="false" />
               <input
                 type="checkbox"
                 name="species[datacomplete]"
+                value="true"
                 checked={@form[:datacomplete].value}
                 class="mt-0.5 rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
               />

--- a/v2/lib/gallformers_web/live/admin/images_live.ex
+++ b/v2/lib/gallformers_web/live/admin/images_live.ex
@@ -328,6 +328,7 @@ defmodule GallformersWeb.AdminImagesLive do
               >{@editing_image.caption || ""}</textarea>
             </div>
             <div class="flex items-center gap-2">
+              <input type="hidden" name="default" value="false" />
               <input
                 type="checkbox"
                 name="default"

--- a/v2/lib/gallformers_web/live/admin/profile_live.ex
+++ b/v2/lib/gallformers_web/live/admin/profile_live.ex
@@ -234,6 +234,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
             <%!-- Show on About Page --%>
             <div class="mb-6">
               <div class="flex items-center">
+                <input type="hidden" name={@form[:show_on_about].name} value="false" />
                 <input
                   type="checkbox"
                   id={@form[:show_on_about].id}

--- a/v2/lib/gallformers_web/live/admin/source_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/source_live/form.ex
@@ -218,6 +218,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
           <%!-- Row: Data Complete checkbox --%>
           <div class="mb-3">
             <label class="flex items-center gap-2">
+              <input type="hidden" name={@form[:datacomplete].name} value="false" />
               <input
                 type="checkbox"
                 name={@form[:datacomplete].name}

--- a/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
@@ -511,6 +511,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
 
                       <div>
                         <label class="flex items-center gap-2 cursor-pointer">
+                          <input type="hidden" name="species_source[useasdefault]" value="false" />
                           <input
                             type="checkbox"
                             name="species_source[useasdefault]"

--- a/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
@@ -345,6 +345,11 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.QuickFind do
                               <div>
                                 <label class="flex items-center gap-2 cursor-pointer">
                                   <input
+                                    type="hidden"
+                                    name="species_source[useasdefault]"
+                                    value="false"
+                                  />
+                                  <input
                                     type="checkbox"
                                     name="species_source[useasdefault]"
                                     value="true"


### PR DESCRIPTION
## Summary
- Add hidden input pattern to form-submitted checkboxes for proper false value submission
- Fixes 8 checkboxes across admin forms (datacomplete, useasdefault, is_published, show_on_about, default)

## Test plan
- [x] All 560 tests pass
- [x] mix precommit passes

Closes gallformers-rj2c