### PR TITLE
gallformers-5ptl: Convert core+admin components to semantic CSS

### DIFF
--- a/v2/lib/gallformers_web/components/core_components.ex
+++ b/v2/lib/gallformers_web/components/core_components.ex
@@ -487,11 +487,8 @@ defmodule GallformersWeb.CoreComponents do
     ~H"""
     <span
       class={[
-        "inline-flex items-center px-2 py-1 text-xs font-medium rounded-full cursor-help",
-        if(@complete,
-          do: "bg-green-100 text-green-800",
-          else: "bg-yellow-100 text-yellow-800"
-        )
+        "gf-badge cursor-help",
+        if(@complete, do: "gf-badge-success", else: "gf-badge-warning")
       ]}
       title={if @complete, do: @complete_tooltip, else: @incomplete_tooltip}
     >

--- a/v2/lib/gallformers_web/components/form_components.ex
+++ b/v2/lib/gallformers_web/components/form_components.ex
@@ -745,7 +745,7 @@ defmodule GallformersWeb.FormComponents do
       data-input-id={"#{@id}-input"}
       class={@class}
     >
-      <label class="block text-base font-medium text-gray-700 mb-1">{@label}</label>
+      <label class="gf-label">{@label}</label>
       <%= if @selected do %>
         <div
           id={"#{@id}-selected"}
@@ -777,7 +777,7 @@ defmodule GallformersWeb.FormComponents do
             phx-keyup={@search_event}
             phx-debounce="200"
             placeholder={@placeholder}
-            class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
+            class="gf-input"
             role="combobox"
             aria-expanded={length(@results) > 0}
             aria-controls={"#{@id}-results"}
@@ -883,20 +883,20 @@ defmodule GallformersWeb.FormComponents do
       data-input-id={@id}
       class="mb-2"
     >
-      <label class="block text-base font-medium text-gray-700 mb-1">{@label}</label>
+      <label class="gf-label">{@label}</label>
       <div class="relative">
         <%!-- Selected tags and input --%>
         <div class="flex flex-wrap gap-1 p-2 border border-gray-300 rounded-md bg-white min-h-[42px]">
           <span
             :for={opt <- @selected_options}
-            class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-800 rounded text-sm"
+            class="gf-chip gf-chip-sm"
           >
             {Map.get(opt, @option_label)}
             <button
               type="button"
               phx-click={"#{@name}_remove"}
               phx-value-id={to_string(opt.id)}
-              class="text-gray-500 hover:text-gray-700"
+              class="gf-chip-remove"
             >
               <.icon name="ph-x" class="size-3" />
             </button>

--- a/v2/lib/gallformers_web/live/admin/form_components.ex
+++ b/v2/lib/gallformers_web/live/admin/form_components.ex
@@ -33,20 +33,14 @@ defmodule GallformersWeb.Admin.FormComponents do
       <button
         type="button"
         phx-click="request_cancel"
-        class="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+        class="gf-btn gf-btn-soft"
       >
         Cancel
       </button>
       <button
         type="submit"
         disabled={not @form_dirty}
-        class={[
-          "px-4 py-2 text-sm rounded",
-          if(@form_dirty,
-            do: "bg-gf-maroon text-white hover:bg-gf-maroon/90",
-            else: "bg-gray-300 text-gray-500 cursor-not-allowed"
-          )
-        ]}
+        class="gf-btn gf-btn-primary"
       >
         {if @mode == :new, do: @create_label, else: @save_label}
       </button>
@@ -85,7 +79,7 @@ defmodule GallformersWeb.Admin.FormComponents do
   def alias_editor(assigns) do
     ~H"""
     <div class="mb-3">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Aliases:</label>
+      <label class="gf-label gf-label-sm">Aliases:</label>
       <div class="border border-gray-300 rounded">
         <table class="w-full text-sm">
           <thead class="bg-gray-50">
@@ -118,14 +112,14 @@ defmodule GallformersWeb.Admin.FormComponents do
                   placeholder="New alias..."
                   phx-keyup="update_new_alias"
                   phx-value-type={@new_alias_type}
-                  class="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  class="gf-input text-sm"
                 />
               </td>
               <td class="px-3 py-1.5">
                 <select
                   phx-change="update_new_alias"
                   phx-value-name={@new_alias_name}
-                  class="w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                  class="gf-select text-sm"
                 >
                   <%= for {label, value} <- alias_type_options() do %>
                     <option value={value} selected={@new_alias_type == value}>

--- a/v2/test/gallformers_web/live/admin/gall_live/form_test.exs
+++ b/v2/test/gallformers_web/live/admin/gall_live/form_test.exs
@@ -280,16 +280,16 @@ defmodule GallformersWeb.Admin.GallLive.FormTest do
 
     test "update_detachable marks form as dirty", %{conn: conn} do
       gall = require_gall()
-      {:ok, view, html_before} = live(conn, ~p"/admin/galls/#{gall.id}")
+      {:ok, view, _html} = live(conn, ~p"/admin/galls/#{gall.id}")
 
-      # Initially form should not be dirty
-      assert html_before =~ "cursor-not-allowed"
+      # Initially form should not be dirty (save button disabled)
+      assert has_element?(view, "button[type='submit'][disabled]")
 
       # Change detachable value
-      html_after = render_click(view, "update_detachable", %{"value" => "2"})
+      render_click(view, "update_detachable", %{"value" => "2"})
 
       # Form should now be dirty (save button enabled)
-      refute html_after =~ "cursor-not-allowed"
+      refute has_element?(view, "button[type='submit'][disabled]")
     end
 
     test "update_detachable updates the select value", %{conn: conn} do
@@ -310,16 +310,16 @@ defmodule GallformersWeb.Admin.GallLive.FormTest do
 
     test "toggle_undescribed marks form as dirty", %{conn: conn} do
       gall = require_gall()
-      {:ok, view, html_before} = live(conn, ~p"/admin/galls/#{gall.id}")
+      {:ok, view, _html} = live(conn, ~p"/admin/galls/#{gall.id}")
 
-      # Initially form should not be dirty
-      assert html_before =~ "cursor-not-allowed"
+      # Initially form should not be dirty (save button disabled)
+      assert has_element?(view, "button[type='submit'][disabled]")
 
       # Toggle undescribed
-      html_after = render_click(view, "toggle_undescribed", %{})
+      render_click(view, "toggle_undescribed", %{})
 
       # Form should now be dirty (save button enabled)
-      refute html_after =~ "cursor-not-allowed"
+      refute has_element?(view, "button[type='submit'][disabled]")
     end
 
     test "toggle_undescribed toggles checkbox state", %{conn: conn} do

--- a/v2/test/gallformers_web/live/admin/host_live/form_test.exs
+++ b/v2/test/gallformers_web/live/admin/host_live/form_test.exs
@@ -59,9 +59,9 @@ defmodule GallformersWeb.Admin.HostLive.FormTest do
     end
 
     test "save button is disabled initially", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/admin/hosts/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/hosts/new")
 
-      assert html =~ "cursor-not-allowed"
+      assert has_element?(view, "button[type='submit'][disabled]")
     end
 
     test "shows back link to hosts list", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Convert typeahead, multi_select_typeahead, and data_complete_badge to semantic CSS classes
- Convert form_actions and alias_editor in admin form components to semantic CSS
- Update tests to check for disabled attribute instead of cursor-not-allowed class

Closes gallformers-5ptl