### PR TITLE
gallformers-phms: Convert form_components to semantic CSS

### DIFF
--- a/v2/assets/css/app.css
+++ b/v2/assets/css/app.css
@@ -750,3 +750,257 @@ a.gf-btn-primary:hover {
 .gf-card-body {
   padding: 1rem;
 }
+
+/* ============================================
+   Pill Toggle Styles
+   ============================================ */
+
+.gf-pill {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  border: 1px solid;
+  transition: all 0.15s ease-in-out;
+  cursor: pointer;
+}
+
+.gf-pill-selected {
+  background-color: #661419;
+  color: white;
+  border-color: #661419;
+}
+
+.gf-pill-unselected {
+  background-color: white;
+  color: #374151;
+  border-color: #d1d5db;
+}
+
+.gf-pill-unselected:hover {
+  border-color: #661419;
+}
+
+/* ============================================
+   Search Input Styles
+   ============================================ */
+
+.gf-search-input {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 0.75rem 0.75rem 2.5rem;
+  font-size: 1.125rem;
+  line-height: 1.25;
+  color: #1f2937;
+  background-color: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.gf-search-input:focus {
+  outline: none;
+  border-color: #661419;
+  box-shadow: 0 0 0 1px #661419;
+}
+
+.gf-search-input::placeholder {
+  color: #6b7280;
+}
+
+/* ============================================
+   Toggle Switch Styles
+   ============================================ */
+
+.gf-toggle {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  background-color: #e5e7eb;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.gf-toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  transition: transform 0.2s ease-in-out;
+}
+
+.gf-toggle-checked {
+  background-color: #661419;
+}
+
+.gf-toggle-checked::after {
+  transform: translateX(100%);
+  border-color: white;
+}
+
+.gf-toggle:focus-within {
+  box-shadow: 0 0 0 2px rgba(102, 20, 25, 0.5);
+}
+
+.gf-toggle-track {
+  width: 2.75rem;
+  height: 1.5rem;
+  background-color: #e5e7eb;
+  border-radius: 9999px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.gf-toggle-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  transition: transform 0.2s ease-in-out;
+}
+
+/* ============================================
+   Radio Button Styles
+   ============================================ */
+
+.gf-radio {
+  width: 1rem;
+  height: 1rem;
+  color: #661419;
+  border: 1px solid #d1d5db;
+  cursor: pointer;
+}
+
+.gf-radio:checked {
+  background-color: #661419;
+  border-color: #661419;
+}
+
+.gf-radio:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(102, 20, 25, 0.5);
+}
+
+/* ============================================
+   File Dropzone Styles
+   ============================================ */
+
+.gf-dropzone {
+  display: flex;
+  justify-content: center;
+  padding: 1.25rem 1.5rem 1.5rem;
+  border: 2px dashed #d1d5db;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease-in-out;
+}
+
+.gf-dropzone:hover {
+  border-color: #661419;
+}
+
+.gf-dropzone-link {
+  position: relative;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  color: #661419;
+}
+
+.gf-dropzone-link:hover {
+  color: rgba(102, 20, 25, 0.8);
+}
+
+/* ============================================
+   Multi-Select Container Styles
+   ============================================ */
+
+.gf-multi-select-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.375rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.25rem;
+  background-color: white;
+  min-height: 2.125rem;
+  cursor: text;
+}
+
+.gf-multi-select-container-md {
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  min-height: 2.625rem;
+}
+
+.gf-multi-select-input {
+  flex: 1;
+  min-width: 60px;
+  border: 0;
+  padding: 0;
+  font-size: 0.75rem;
+}
+
+.gf-multi-select-input:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.gf-multi-select-input-md {
+  min-width: 80px;
+  font-size: 1rem;
+}
+
+.gf-multi-select-dropdown {
+  position: absolute;
+  z-index: 20;
+  margin-top: 0.25rem;
+  width: 100%;
+  background-color: white;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  border-radius: 0.25rem;
+  border: 1px solid #e5e7eb;
+  max-height: 8rem;
+  overflow: auto;
+}
+
+.gf-multi-select-dropdown-md {
+  border-radius: 0.375rem;
+  max-height: 12rem;
+}
+
+.gf-multi-select-option {
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+  font-size: 0.75rem;
+}
+
+/* ============================================
+   Form Helper Text Styles
+   ============================================ */
+
+.gf-hint {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.gf-error {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #dc2626;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/v2/lib/gallformers_web/components/form_components.ex
+++ b/v2/lib/gallformers_web/components/form_components.ex
@@ -117,7 +117,7 @@ defmodule GallformersWeb.FormComponents do
   def multi_select(assigns) do
     ~H"""
     <div id={@id} class={@class}>
-      <label :if={@label} class="block text-base font-medium text-gray-700 mb-2">
+      <label :if={@label} class="gf-label mb-2">
         {@label}
       </label>
       <div class="flex flex-wrap gap-2">
@@ -127,11 +127,10 @@ defmodule GallformersWeb.FormComponents do
           phx-click={@on_toggle}
           phx-value-value={option.value}
           class={[
-            "px-3 py-1 rounded-full text-sm border transition-colors",
-            (option.value in @selected || to_string(option.value) in @selected) &&
-              "bg-gf-maroon text-white border-gf-maroon",
+            "gf-pill",
+            (option.value in @selected || to_string(option.value) in @selected) && "gf-pill-selected",
             !(option.value in @selected || to_string(option.value) in @selected) &&
-              "bg-white text-gray-700 border-gray-300 hover:border-gf-maroon"
+              "gf-pill-unselected"
           ]}
         >
           {option.label}
@@ -173,7 +172,7 @@ defmodule GallformersWeb.FormComponents do
         name={@name}
         value={@value}
         placeholder={@placeholder}
-        class="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-md leading-5 bg-white text-lg placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
+        class="gf-search-input"
         {@rest}
       />
     </div>
@@ -203,15 +202,15 @@ defmodule GallformersWeb.FormComponents do
   def field_wrapper(assigns) do
     ~H"""
     <div class={["mb-4", @class]}>
-      <label class="block text-base font-medium text-gray-700 mb-1">
+      <label class="gf-label">
         {@label}
         <span :if={@required} class="text-red-500">*</span>
       </label>
       {render_slot(@inner_block)}
-      <p :if={@hint && !@error} class="mt-1 text-sm text-gray-500">
+      <p :if={@hint && !@error} class="gf-hint">
         {@hint}
       </p>
-      <p :if={@error} class="mt-1 text-sm text-red-500 flex items-center gap-1">
+      <p :if={@error} class="gf-error">
         <.icon name="ph-warning-circle" class="size-4" />
         {@error}
       </p>
@@ -254,10 +253,10 @@ defmodule GallformersWeb.FormComponents do
           class="sr-only peer"
           {@rest}
         />
-        <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-gf-maroon/50 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-gf-maroon">
+        <div class="gf-toggle-track peer peer-checked:bg-gf-maroon peer-focus:ring-2 peer-focus:ring-gf-maroon/50 peer-checked:after:translate-x-full peer-checked:after:border-white">
         </div>
       </div>
-      <span :if={@label} class="ml-3 text-base font-medium text-gray-700">{@label}</span>
+      <span :if={@label} class="gf-label ml-3 mb-0">{@label}</span>
     </label>
     """
   end
@@ -286,7 +285,7 @@ defmodule GallformersWeb.FormComponents do
   def radio_group(assigns) do
     ~H"""
     <fieldset id={@id} class={@class}>
-      <legend :if={@label} class="text-base font-medium text-gray-700 mb-2">{@label}</legend>
+      <legend :if={@label} class="gf-label mb-2">{@label}</legend>
       <div class="space-y-2">
         <label :for={option <- @options} class="flex items-center">
           <input
@@ -294,11 +293,11 @@ defmodule GallformersWeb.FormComponents do
             name={@name}
             value={option.value}
             checked={@value == option.value || to_string(@value) == to_string(option.value)}
-            class="h-4 w-4 text-gf-maroon focus:ring-gf-maroon border-gray-300"
+            class="gf-radio"
             {@rest}
           />
           <span class="ml-2 text-sm text-gray-700">{option.label}</span>
-          <span :if={option[:description]} class="ml-1 text-sm text-gray-500">
+          <span :if={option[:description]} class="gf-hint ml-1">
             - {option.description}
           </span>
         </label>
@@ -329,23 +328,19 @@ defmodule GallformersWeb.FormComponents do
     ~H"""
     <div
       id={@id}
-      class={[
-        "flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md",
-        "hover:border-gf-maroon transition-colors cursor-pointer",
-        @class
-      ]}
+      class={["gf-dropzone", @class]}
       phx-drop-target={@upload.ref}
     >
       <div class="space-y-1 text-center">
         <.icon name="ph-cloud-arrow-up" class="mx-auto size-12 text-gray-400" />
         <div class="flex text-sm text-gray-600">
-          <label class="relative cursor-pointer rounded-md font-medium text-gf-maroon hover:text-gf-maroon/80">
+          <label class="gf-dropzone-link">
             <span>{gettext("Upload a file")}</span>
             <.live_file_input upload={@upload} class="sr-only" />
           </label>
           <p class="pl-1">{gettext("or drag and drop")}</p>
         </div>
-        <p class="text-xs text-gray-500">{@label}</p>
+        <p class="gf-hint text-xs">{@label}</p>
       </div>
     </div>
     """
@@ -535,39 +530,19 @@ defmodule GallformersWeb.FormComponents do
         result_label
       )
 
-    # Size-based classes
-    {container_class, chip_class, input_class, dropdown_class} =
-      case assigns.size do
-        "sm" ->
-          {
-            "flex flex-wrap gap-1 p-1.5 border border-gray-300 rounded bg-white min-h-[34px] cursor-text",
-            "inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-blue-100 text-blue-800 rounded text-xs",
-            "flex-1 min-w-[60px] border-0 p-0 text-xs focus:ring-0 focus:outline-none",
-            "absolute z-20 mt-1 w-full bg-white shadow-lg rounded border border-gray-200 max-h-32 overflow-auto"
-          }
-
-        "md" ->
-          {
-            "flex flex-wrap gap-1 p-2 border border-gray-300 rounded-md bg-white min-h-[42px] cursor-text",
-            "inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-800 rounded text-sm",
-            "flex-1 min-w-[80px] border-0 p-0 text-base focus:ring-0 focus:outline-none",
-            "absolute z-20 mt-1 w-full bg-white shadow-lg rounded-md border border-gray-200 max-h-48 overflow-auto"
-          }
-      end
+    # Size-based classes - use semantic CSS with size modifiers
+    is_md = assigns.size == "md"
 
     assigns =
       assigns
       |> assign(:available, available)
       |> assign(:result_id_resolved, result_id)
       |> assign(:result_label_resolved, result_label)
-      |> assign(:container_class, container_class)
-      |> assign(:chip_class, chip_class)
-      |> assign(:input_class, input_class)
-      |> assign(:dropdown_class, dropdown_class)
+      |> assign(:is_md, is_md)
 
     ~H"""
     <div class={@class}>
-      <label :if={@label} class="block text-sm font-medium text-gray-700 mb-1">{@label}</label>
+      <label :if={@label} class="gf-label">{@label}</label>
       <div
         id={@id}
         phx-hook="Typeahead"
@@ -575,13 +550,13 @@ defmodule GallformersWeb.FormComponents do
         class="relative"
       >
         <div
-          class={@container_class}
+          class={["gf-multi-select-container", @is_md && "gf-multi-select-container-md"]}
           phx-click={@on_open}
           phx-value-type={@type}
         >
           <span
             :for={item <- @selected}
-            class={@chip_class}
+            class={["gf-chip", !@is_md && "gf-chip-sm"]}
           >
             {get_display_label(item, @item_label)}
             <button
@@ -589,7 +564,7 @@ defmodule GallformersWeb.FormComponents do
               phx-click={@on_remove}
               phx-value-type={@type}
               phx-value-id={get_item_id(item, @item_id)}
-              class="text-blue-600 hover:text-blue-800"
+              class="gf-chip-remove"
             >
               <.icon name="ph-x" class="h-3 w-3" />
             </button>
@@ -603,7 +578,7 @@ defmodule GallformersWeb.FormComponents do
             phx-keyup={@on_search}
             phx-focus={@on_open}
             phx-value-type={@type}
-            class={@input_class}
+            class={["gf-multi-select-input", @is_md && "gf-multi-select-input-md"]}
           />
         </div>
         <%= if @dropdown_open && @available != [] do %>
@@ -611,7 +586,7 @@ defmodule GallformersWeb.FormComponents do
             id={"#{@id}-results"}
             data-typeahead-results
             phx-click-away={@on_close}
-            class={@dropdown_class}
+            class={["gf-multi-select-dropdown", @is_md && "gf-multi-select-dropdown-md"]}
           >
             <button
               :for={opt <- Enum.take(@available, 10)}
@@ -620,7 +595,7 @@ defmodule GallformersWeb.FormComponents do
               phx-click={@on_add}
               phx-value-type={@type}
               phx-value-id={get_item_id(opt, @result_id_resolved)}
-              class="w-full px-2 py-1 text-left text-xs hover:bg-gray-100 data-[highlighted]:bg-gray-100"
+              class="gf-multi-select-option hover:bg-gray-100 data-[highlighted]:bg-gray-100"
             >
               {get_display_label(opt, @result_label_resolved)}
             </button>


### PR DESCRIPTION
## Summary
- Convert 7 form components from inline Tailwind to semantic CSS classes
- Add new `.gf-*` classes for pills, search input, toggle, radio, dropzone, and multi-select
- Fix multi_select_dropdown label size bug (text-sm → text-base via .gf-label)

## Components converted
1. multi_select/1 - pill toggles
2. search_input/1 - search with icon
3. field_wrapper/1 - field container
4. toggle/1 - toggle switch
5. radio_group/1 - radio buttons
6. file_dropzone/1 - file upload
7. multi_select_dropdown/1 - chips + dropdown

## Test plan
- [x] mix precommit passes (560 tests, 0 failures)

Closes gallformers-phms