### PR TITLE
gallformers-myaq: Standardize label styling

### DIFF
--- a/v2/lib/gallformers_web/components/form_components.ex
+++ b/v2/lib/gallformers_web/components/form_components.ex
@@ -212,7 +212,7 @@ defmodule GallformersWeb.FormComponents do
             class="gf-radio"
             {@rest}
           />
-          <span class="ml-2 text-sm text-gray-700">{option.label}</span>
+          <span class="ml-2 text-base text-gray-700">{option.label}</span>
           <span :if={option[:description]} class="gf-hint ml-1">
             - {option.description}
           </span>

--- a/v2/lib/gallformers_web/live/admin/article_admin_live.ex
+++ b/v2/lib/gallformers_web/live/admin/article_admin_live.ex
@@ -268,7 +268,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
                   <.input field={@form[:author]} label="Author" required />
                 </div>
                 <div class="flex-1 flex flex-col min-h-0">
-                  <label class="block text-sm font-medium text-gray-700 mb-1">
+                  <label class="gf-label">
                     Content (Markdown)
                   </label>
                   <textarea
@@ -337,7 +337,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
                     checked={Phoenix.HTML.Form.input_value(@form, :is_published) == true}
                     class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
                   />
-                  <label for={@form[:is_published].id} class="text-sm text-gray-700">
+                  <label for={@form[:is_published].id} class="text-base text-gray-700">
                     Published
                   </label>
                 </div>

--- a/v2/lib/gallformers_web/live/admin/filter_terms_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/filter_terms_live/form.ex
@@ -142,7 +142,7 @@ defmodule GallformersWeb.Admin.FilterTermsLive.Form do
 
         <.form for={@form} id="filter-field-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">
+            <label class="gf-label">
               {FilterFields.singular_label(@filter_type)}:
             </label>
             <input
@@ -157,7 +157,7 @@ defmodule GallformersWeb.Admin.FilterTermsLive.Form do
 
           <%= if FilterFields.has_description?(@filter_type) do %>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Description:</label>
+              <label class="gf-label">Description:</label>
               <textarea
                 name={@form[:description].name}
                 rows="4"

--- a/v2/lib/gallformers_web/live/admin/filter_terms_live/index.ex
+++ b/v2/lib/gallformers_web/live/admin/filter_terms_live/index.ex
@@ -103,7 +103,7 @@ defmodule GallformersWeb.Admin.FilterTermsLive.Index do
         <%!-- Type selector and New button --%>
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div class="flex items-center gap-4">
-            <label for="filter-type" class="text-sm font-medium text-gray-700">
+            <label for="filter-type" class="gf-label mb-0">
               Filter Type:
             </label>
             <select

--- a/v2/lib/gallformers_web/live/admin/form_components.ex
+++ b/v2/lib/gallformers_web/live/admin/form_components.ex
@@ -79,7 +79,7 @@ defmodule GallformersWeb.Admin.FormComponents do
   def alias_editor(assigns) do
     ~H"""
     <div class="mb-3">
-      <label class="gf-label gf-label-sm">Aliases:</label>
+      <label class="gf-label">Aliases:</label>
       <div class="border border-gray-300 rounded">
         <table class="w-full text-sm">
           <thead class="bg-gray-50">

--- a/v2/lib/gallformers_web/live/admin/gall_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/gall_live/form.ex
@@ -661,7 +661,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
         <.form for={@form} id="gall-form" phx-change="validate" phx-submit="save">
           <%!-- Row: Name --%>
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name (binomial):</label>
+            <label class="gf-label">Name (binomial):</label>
             <%= if @mode == :edit do %>
               <div class="flex gap-2">
                 <input
@@ -692,7 +692,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
           <%!-- Row: Genus | Family --%>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 Genus (filled automatically):
               </label>
               <input
@@ -703,7 +703,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 Family (required):
               </label>
               <input
@@ -744,7 +744,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
                 </p>
               <% end %>
             <% else %>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Hosts (required):</label>
+              <label class="gf-label">Hosts (required):</label>
               <input
                 type="text"
                 disabled
@@ -758,7 +758,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
             <%!-- Row: Detachable | Walls | Cells | Alignment --%>
             <div class="grid grid-cols-4 gap-3 mb-3">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Detachable:</label>
+                <label class="gf-label">Detachable:</label>
                 <select
                   phx-change="update_detachable"
                   name="value"
@@ -913,7 +913,7 @@ defmodule GallformersWeb.Admin.GallLive.Form do
                 on_close="close_filter_dropdown"
               />
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Abundance:</label>
+                <label class="gf-label">Abundance:</label>
                 <.input
                   field={@form[:abundance_id]}
                   type="select"

--- a/v2/lib/gallformers_web/live/admin/gallhost_live.ex
+++ b/v2/lib/gallformers_web/live/admin/gallhost_live.ex
@@ -371,7 +371,7 @@ defmodule GallformersWeb.Admin.GallhostLive do
                   </p>
                 <% end %>
               <% else %>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Hosts:</label>
+                <label class="gf-label">Hosts:</label>
                 <div class="flex flex-wrap gap-1 p-2 border border-gray-200 bg-gray-50 rounded min-h-[42px]">
                   <span class="text-gray-400 text-sm">Select a gall first</span>
                 </div>
@@ -381,7 +381,7 @@ defmodule GallformersWeb.Admin.GallhostLive do
             <%!-- Range Section --%>
             <div class="mb-4">
               <div class="flex items-center gap-2 mb-1">
-                <label class="text-sm font-medium text-gray-700">Range:</label>
+                <label class="gf-label mb-0">Range:</label>
                 <span
                   class="text-gray-400 cursor-help"
                   title="By default the range for a gall is the union of all places that the selected Hosts occur in. Click on places to exclude them from the gall's range. Do not exclude places based solely on a lack of observations."

--- a/v2/lib/gallformers_web/live/admin/glossary_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/glossary_live/form.ex
@@ -64,7 +64,7 @@ defmodule GallformersWeb.Admin.GlossaryLive.Form do
 
         <.form for={@form} id="glossary-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Word:</label>
+            <label class="gf-label">Word:</label>
             <input
               type="text"
               name={@form[:word].name}
@@ -77,7 +77,7 @@ defmodule GallformersWeb.Admin.GlossaryLive.Form do
           </div>
 
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Definition:</label>
+            <label class="gf-label">Definition:</label>
             <textarea
               name={@form[:definition].name}
               rows="4"
@@ -88,7 +88,7 @@ defmodule GallformersWeb.Admin.GlossaryLive.Form do
           </div>
 
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Source URLs:</label>
+            <label class="gf-label">Source URLs:</label>
             <textarea
               name={@form[:urls].name}
               rows="2"

--- a/v2/lib/gallformers_web/live/admin/host_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/host_live/form.ex
@@ -432,7 +432,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
         <.form for={@form} id="host-form" phx-change="validate" phx-submit="save">
           <%!-- Row: Name --%>
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name (binomial):</label>
+            <label class="gf-label">Name (binomial):</label>
             <%= if @mode == :edit do %>
               <div class="flex gap-2">
                 <input
@@ -463,7 +463,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
           <%!-- Row: Genus | Family --%>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 Genus (filled automatically):
               </label>
               <input
@@ -474,7 +474,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 Family:
               </label>
               <input
@@ -489,7 +489,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
           <%!-- Row: Section | Abundance --%>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Section:</label>
+              <label class="gf-label">Section:</label>
               <input
                 type="text"
                 value={if @taxonomy && @taxonomy.section, do: @taxonomy.section, else: ""}
@@ -498,7 +498,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Abundance:</label>
+              <label class="gf-label">Abundance:</label>
               <.input
                 field={@form[:abundance_id]}
                 type="select"
@@ -551,7 +551,7 @@ defmodule GallformersWeb.Admin.HostLive.Form do
               </div>
               <%!-- Map --%>
               <div class="col-span-5">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Range:</label>
+                <label class="gf-label">Range:</label>
                 <%= if @mode == :edit do %>
                   <div
                     id="host-range-map"

--- a/v2/lib/gallformers_web/live/admin/images_live.ex
+++ b/v2/lib/gallformers_web/live/admin/images_live.ex
@@ -240,7 +240,7 @@ defmodule GallformersWeb.AdminImagesLive do
           <:body>
             <form id="edit-image-form" phx-submit="save_image" class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">
+                <label class="gf-label">
                   Creator / Photographer
                 </label>
                 <input
@@ -251,7 +251,7 @@ defmodule GallformersWeb.AdminImagesLive do
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Attribution</label>
+                <label class="gf-label">Attribution</label>
                 <input
                   type="text"
                   name="attribution"
@@ -260,7 +260,7 @@ defmodule GallformersWeb.AdminImagesLive do
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">License</label>
+                <label class="gf-label">License</label>
                 <select
                   name="license"
                   phx-change="update_license"
@@ -277,7 +277,7 @@ defmodule GallformersWeb.AdminImagesLive do
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">License URL</label>
+                <label class="gf-label">License URL</label>
                 <%= if Licenses.url_readonly?(@editing_image.license) do %>
                   <input
                     type="text"
@@ -310,7 +310,7 @@ defmodule GallformersWeb.AdminImagesLive do
                 <% end %>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">
+                <label class="gf-label">
                   Source URL (e.g., iNaturalist)
                 </label>
                 <input
@@ -321,7 +321,7 @@ defmodule GallformersWeb.AdminImagesLive do
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Caption</label>
+                <label class="gf-label">Caption</label>
                 <textarea
                   name="caption"
                   rows="3"
@@ -338,7 +338,7 @@ defmodule GallformersWeb.AdminImagesLive do
                   id="default-checkbox"
                   class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
                 />
-                <label for="default-checkbox" class="text-sm text-gray-700">
+                <label for="default-checkbox" class="text-base text-gray-700">
                   Set as default image
                 </label>
               </div>

--- a/v2/lib/gallformers_web/live/admin/place_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/place_live/form.ex
@@ -62,7 +62,7 @@ defmodule GallformersWeb.Admin.PlaceLive.Form do
 
         <.form for={@form} id="place-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name:</label>
+            <label class="gf-label">Name:</label>
             <input
               type="text"
               name={@form[:name].name}
@@ -75,7 +75,7 @@ defmodule GallformersWeb.Admin.PlaceLive.Form do
 
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Code:</label>
+              <label class="gf-label">Code:</label>
               <input
                 type="text"
                 name={@form[:code].name}
@@ -87,7 +87,7 @@ defmodule GallformersWeb.Admin.PlaceLive.Form do
               <p class="mt-1 text-xs text-gray-500">Standard 2-letter postal code</p>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Type:</label>
+              <label class="gf-label">Type:</label>
               <select
                 name={@form[:type].name}
                 required

--- a/v2/lib/gallformers_web/live/admin/profile_live.ex
+++ b/v2/lib/gallformers_web/live/admin/profile_live.ex
@@ -119,7 +119,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
           <.form for={@form} id="profile-form" phx-change="validate" phx-submit="save">
             <%!-- Display Name --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Display Name:</label>
+              <label class="gf-label">Display Name:</label>
               <input
                 type="text"
                 name={@form[:display_name].name}
@@ -131,7 +131,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- Nickname (read-only, from Auth0) --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Auth0 Nickname:</label>
+              <label class="gf-label">Auth0 Nickname:</label>
               <input
                 type="text"
                 value={@current_user.nickname || "Not set"}
@@ -145,7 +145,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- About Me --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">About Me:</label>
+              <label class="gf-label">About Me:</label>
               <textarea
                 name={@form[:about_me].name}
                 rows="4"
@@ -156,7 +156,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- iNaturalist URL --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 iNaturalist Profile URL:
               </label>
               <input
@@ -170,7 +170,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- Social Media URL --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Social Media URL:</label>
+              <label class="gf-label">Social Media URL:</label>
               <input
                 type="url"
                 name={@form[:social_url].name}
@@ -182,7 +182,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- Personal Website URL --%>
             <div class="mb-3">
-              <label class="block text-sm font-medium text-gray-700 mb-1">
+              <label class="gf-label">
                 Personal Website URL:
               </label>
               <input

--- a/v2/lib/gallformers_web/live/admin/source_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/source_live/form.ex
@@ -88,7 +88,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
         <.form for={@form} id="source-form" phx-change="validate" phx-submit="save">
           <%!-- Row: Title --%>
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Title:</label>
+            <label class="gf-label">Title:</label>
             <input
               type="text"
               name={@form[:title].name}
@@ -102,7 +102,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
           <%!-- Row: Author | Year --%>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Author(s):</label>
+              <label class="gf-label">Author(s):</label>
               <input
                 type="text"
                 name={@form[:author].name}
@@ -113,7 +113,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Publication Year:</label>
+              <label class="gf-label">Publication Year:</label>
               <input
                 type="text"
                 name={@form[:pubyear].name}
@@ -127,7 +127,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
 
           <%!-- Row: Reference Link --%>
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Reference Link:</label>
+            <label class="gf-label">Reference Link:</label>
             <input
               type="url"
               name={@form[:link].name}
@@ -142,7 +142,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
           <% current_license = Phoenix.HTML.Form.input_value(@form, :license) %>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">License:</label>
+              <label class="gf-label">License:</label>
               <select
                 name={@form[:license].name}
                 required
@@ -159,7 +159,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">License Link:</label>
+              <label class="gf-label">License Link:</label>
               <%= if Licenses.url_readonly?(current_license) do %>
                 <input
                   type="url"
@@ -193,7 +193,7 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
 
           <%!-- Row: Citation --%>
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Citation (MLA format):</label>
+            <label class="gf-label">Citation (MLA format):</label>
             <textarea
               name={@form[:citation].name}
               rows="4"

--- a/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
@@ -336,7 +336,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
           <div class="p-4">
             <%!-- Source Selection (sticky at top) --%>
             <div class="mb-6 pb-4 border-b border-gray-200">
-              <label class="block text-sm font-medium text-gray-700 mb-2">
+              <label class="gf-label mb-2">
                 Source:
               </label>
 
@@ -402,7 +402,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
             <%= if @selected_source do %>
               <%!-- Already Mapped Species --%>
               <div class="mb-6">
-                <label class="block text-sm font-medium text-gray-700 mb-2">
+                <label class="gf-label mb-2">
                   Already mapped ({length(@mapped_species)} species):
                 </label>
                 <%= if @mapped_species == [] do %>
@@ -479,7 +479,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
                   >
                     <div class="space-y-4">
                       <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">
+                        <label class="gf-label">
                           Description (info from this source about this species):
                         </label>
                         <.input
@@ -495,7 +495,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
                       </div>
 
                       <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">
+                        <label class="gf-label">
                           External Link (direct link to description page, if available):
                         </label>
                         <.input

--- a/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
@@ -319,7 +319,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.QuickFind do
                           >
                             <div class="space-y-4">
                               <div>
-                                <label class="block text-sm font-medium text-gray-700 mb-1">
+                                <label class="gf-label">
                                   Description:
                                 </label>
                                 <.input
@@ -331,7 +331,7 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.QuickFind do
                               </div>
 
                               <div>
-                                <label class="block text-sm font-medium text-gray-700 mb-1">
+                                <label class="gf-label">
                                   External Link:
                                 </label>
                                 <.input

--- a/v2/lib/gallformers_web/live/admin/taxonomy_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/taxonomy_live/form.ex
@@ -109,7 +109,7 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
 
         <.form for={@form} id="taxonomy-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="block text-sm font-medium text-gray-700 mb-1">Name:</label>
+            <label class="gf-label">Name:</label>
             <input
               type="text"
               name={@form[:name].name}
@@ -122,7 +122,7 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
 
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Type:</label>
+              <label class="gf-label">Type:</label>
               <select
                 name={@form[:type].name}
                 required
@@ -150,7 +150,7 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
               </select>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Description:</label>
+              <label class="gf-label">Description:</label>
               <input
                 type="text"
                 name={@form[:description].name}
@@ -164,7 +164,7 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
 
           <div class="mb-3">
             <%= if @parent_options != [] do %>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Parent:</label>
+              <label class="gf-label">Parent:</label>
               <select
                 name={@form[:parent_id].name}
                 class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
@@ -182,7 +182,7 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
                 Genera belong to families or sections. Sections belong to families.
               </p>
             <% else %>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Parent:</label>
+              <label class="gf-label">Parent:</label>
               <p class="text-sm text-gray-500 italic px-3 py-2">
                 <%= if Phoenix.HTML.Form.input_value(@form, :type) == "family" do %>
                   Families are top-level entries and have no parent.


### PR DESCRIPTION
## Summary
- Replace inline `text-sm font-medium text-gray-700` styling with semantic `.gf-label` class across all admin form components
- Update radio_group option labels to use `text-base` for consistency
- Update checkbox labels in article_admin_live and images_live to use `text-base`

Closes gallformers-myaq