### PR TITLE
gallformers-26u8: Migrate remaining raw HTML form elements

### DIFF
--- a/v2/lib/gallformers_web/live/admin/article_admin_live.ex
+++ b/v2/lib/gallformers_web/live/admin/article_admin_live.ex
@@ -76,29 +76,22 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
               />
             </form>
             <form phx-change="filter_tag" id="article-tag-filter" class="w-48">
-              <select
+              <.input
+                type="select"
                 name="tag"
-                class="w-full px-3 py-3 border border-gray-300 rounded-md text-lg focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">All Tags</option>
-                <option :for={tag <- @all_tags} value={tag} selected={@tag_filter == tag}>
-                  {tag}
-                </option>
-              </select>
+                prompt="All Tags"
+                options={Enum.map(@all_tags, &{&1, &1})}
+                value={@tag_filter}
+              />
             </form>
             <form phx-change="filter_status" id="article-status-filter" class="w-40">
-              <select
+              <.input
+                type="select"
                 name="status"
-                class="w-full px-3 py-3 border border-gray-300 rounded-md text-lg focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">All Status</option>
-                <option value="published" selected={@status_filter == "published"}>
-                  Published
-                </option>
-                <option value="draft" selected={@status_filter == "draft"}>
-                  Draft
-                </option>
-              </select>
+                prompt="All Status"
+                options={[{"Published", "published"}, {"Draft", "draft"}]}
+                value={@status_filter}
+              />
             </form>
           </div>
           <button type="button" phx-click="new_article" class="gf-btn gf-btn-primary">

--- a/v2/lib/gallformers_web/live/admin/filter_terms_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/filter_terms_live/form.ex
@@ -157,13 +157,13 @@ defmodule GallformersWeb.Admin.FilterTermsLive.Form do
 
           <%= if FilterFields.has_description?(@filter_type) do %>
             <div class="mb-3">
-              <label class="gf-label">Description:</label>
-              <textarea
-                name={@form[:description].name}
+              <.input
+                field={@form[:description]}
+                type="textarea"
+                label="Description:"
                 rows="4"
                 placeholder="Enter a description explaining this term"
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >{Phoenix.HTML.Form.input_value(@form, :description)}</textarea>
+              />
               <p class="mt-1 text-xs text-gray-500">
                 A brief explanation of what this term means, shown in the filter guide.
               </p>

--- a/v2/lib/gallformers_web/live/admin/filter_terms_live/index.ex
+++ b/v2/lib/gallformers_web/live/admin/filter_terms_live/index.ex
@@ -102,25 +102,20 @@ defmodule GallformersWeb.Admin.FilterTermsLive.Index do
 
         <%!-- Type selector and New button --%>
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div class="flex items-center gap-4">
-            <label for="filter-type" class="gf-label mb-0">
-              Filter Type:
-            </label>
-            <select
-              id="filter-type"
+          <form phx-change="change_type" class="flex items-center gap-4">
+            <.input
+              type="select"
               name="type"
-              phx-change="change_type"
-              class="gf-select w-auto"
-            >
-              <option
-                :for={type <- FilterFields.filter_types()}
-                value={type}
-                selected={type == @filter_type}
-              >
-                {FilterFields.type_label(type)} ({@counts[type]})
-              </option>
-            </select>
-          </div>
+              label="Filter Type:"
+              options={
+                Enum.map(
+                  FilterFields.filter_types(),
+                  &{FilterFields.type_label(&1) <> " (#{@counts[&1]})", &1}
+                )
+              }
+              value={@filter_type}
+            />
+          </form>
           <.link
             navigate={~p"/admin/filter-terms/new?type=#{@filter_type}"}
             class="gf-btn gf-btn-primary"

--- a/v2/lib/gallformers_web/live/admin/gall_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/gall_live/form.ex
@@ -757,18 +757,15 @@ defmodule GallformersWeb.Admin.GallLive.Form do
           <%= if @mode == :edit do %>
             <%!-- Row: Detachable | Walls | Cells | Alignment --%>
             <div class="grid grid-cols-4 gap-3 mb-3">
-              <div>
-                <label class="gf-label">Detachable:</label>
-                <select
-                  phx-change="update_detachable"
+              <form phx-change="update_detachable">
+                <.input
+                  type="select"
                   name="value"
-                  class="w-full px-2 py-1.5 border border-gray-300 rounded text-sm"
-                >
-                  <%= for {label, id} <- @detachable_options do %>
-                    <option value={id} selected={@detachable == id}>{label}</option>
-                  <% end %>
-                </select>
-              </div>
+                  label="Detachable:"
+                  options={@detachable_options}
+                  value={@detachable}
+                />
+              </form>
               <.multi_select_dropdown
                 id="walls"
                 label="Walls:"

--- a/v2/lib/gallformers_web/live/admin/glossary_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/glossary_live/form.ex
@@ -64,38 +64,36 @@ defmodule GallformersWeb.Admin.GlossaryLive.Form do
 
         <.form for={@form} id="glossary-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="gf-label">Word:</label>
-            <input
+            <.input
+              field={@form[:word]}
               type="text"
-              name={@form[:word].name}
-              value={Phoenix.HTML.Form.input_value(@form, :word)}
+              label="Word:"
               placeholder="Enter term (lowercase unless proper noun)"
               required
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
             />
             <p class="mt-1 text-xs text-gray-500">Use lowercase unless it's a proper name</p>
           </div>
 
           <div class="mb-3">
-            <label class="gf-label">Definition:</label>
-            <textarea
-              name={@form[:definition].name}
+            <.input
+              field={@form[:definition]}
+              type="textarea"
+              label="Definition:"
               rows="4"
-              required
               placeholder="Enter the definition"
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-            >{Phoenix.HTML.Form.input_value(@form, :definition)}</textarea>
+              required
+            />
           </div>
 
           <div class="mb-3">
-            <label class="gf-label">Source URLs:</label>
-            <textarea
-              name={@form[:urls].name}
+            <.input
+              field={@form[:urls]}
+              type="textarea"
+              label="Source URLs:"
               rows="2"
-              required
               placeholder="Enter URLs (one per line)"
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-            >{Phoenix.HTML.Form.input_value(@form, :urls)}</textarea>
+              required
+            />
             <p class="mt-1 text-xs text-gray-500">
               Enter one URL per line. These are the sources for the definition.
             </p>

--- a/v2/lib/gallformers_web/live/admin/images_live.ex
+++ b/v2/lib/gallformers_web/live/admin/images_live.ex
@@ -260,21 +260,16 @@ defmodule GallformersWeb.AdminImagesLive do
                 />
               </div>
               <div>
-                <label class="gf-label">License</label>
-                <select
-                  name="license"
-                  phx-change="update_license"
-                  class="w-full rounded-md border-gray-300 shadow-sm focus:border-gf-maroon focus:ring-gf-maroon"
-                >
-                  <option value="">Select a license</option>
-                  <option
-                    :for={license <- Licenses.all()}
-                    value={license}
-                    selected={@editing_image.license == license}
-                  >
-                    {license}
-                  </option>
-                </select>
+                <form phx-change="update_license">
+                  <.input
+                    type="select"
+                    name="license"
+                    label="License"
+                    prompt="Select a license"
+                    options={Enum.map(Licenses.all(), &{&1, &1})}
+                    value={@editing_image.license}
+                  />
+                </form>
               </div>
               <div>
                 <label class="gf-label">License URL</label>
@@ -321,12 +316,13 @@ defmodule GallformersWeb.AdminImagesLive do
                 />
               </div>
               <div>
-                <label class="gf-label">Caption</label>
-                <textarea
+                <.input
+                  type="textarea"
                   name="caption"
+                  label="Caption"
                   rows="3"
-                  class="w-full rounded-md border-gray-300 shadow-sm focus:border-gf-maroon focus:ring-gf-maroon"
-                >{@editing_image.caption || ""}</textarea>
+                  value={@editing_image.caption || ""}
+                />
               </div>
               <div class="flex items-center gap-2">
                 <input type="hidden" name="default" value="false" />

--- a/v2/lib/gallformers_web/live/admin/place_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/place_live/form.ex
@@ -62,46 +62,35 @@ defmodule GallformersWeb.Admin.PlaceLive.Form do
 
         <.form for={@form} id="place-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="gf-label">Name:</label>
-            <input
+            <.input
+              field={@form[:name]}
               type="text"
-              name={@form[:name].name}
-              value={Phoenix.HTML.Form.input_value(@form, :name)}
+              label="Name:"
               placeholder="e.g., California, Ontario"
               required
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
             />
           </div>
 
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="gf-label">Code:</label>
-              <input
+              <.input
+                field={@form[:code]}
                 type="text"
-                name={@form[:code].name}
-                value={Phoenix.HTML.Form.input_value(@form, :code)}
+                label="Code:"
                 placeholder="e.g., CA, ON"
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
               />
               <p class="mt-1 text-xs text-gray-500">Standard 2-letter postal code</p>
             </div>
             <div>
-              <label class="gf-label">Type:</label>
-              <select
-                name={@form[:type].name}
+              <.input
+                field={@form[:type]}
+                type="select"
+                label="Type:"
+                prompt="Select type"
+                options={Enum.map(Place.place_types(), &{&1, &1})}
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">Select type</option>
-                <option
-                  :for={type <- Place.place_types()}
-                  value={type}
-                  selected={Phoenix.HTML.Form.input_value(@form, :type) == type}
-                >
-                  {type}
-                </option>
-              </select>
+              />
             </div>
           </div>
 

--- a/v2/lib/gallformers_web/live/admin/profile_live.ex
+++ b/v2/lib/gallformers_web/live/admin/profile_live.ex
@@ -145,13 +145,13 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- About Me --%>
             <div class="mb-3">
-              <label class="gf-label">About Me:</label>
-              <textarea
-                name={@form[:about_me].name}
+              <.input
+                field={@form[:about_me]}
+                type="textarea"
+                label="About Me:"
                 rows="4"
                 placeholder="Tell us a bit about yourself..."
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >{Phoenix.HTML.Form.input_value(@form, :about_me)}</textarea>
+              />
             </div>
 
             <%!-- iNaturalist URL --%>

--- a/v2/lib/gallformers_web/live/admin/source_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/source_live/form.ex
@@ -142,21 +142,14 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
           <% current_license = Phoenix.HTML.Form.input_value(@form, :license) %>
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="gf-label">License:</label>
-              <select
-                name={@form[:license].name}
+              <.input
+                field={@form[:license]}
+                type="select"
+                label="License:"
+                prompt="Select license"
+                options={Enum.map(Source.license_types(), &{&1, &1})}
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">Select license</option>
-                <option
-                  :for={license <- Source.license_types()}
-                  value={license}
-                  selected={current_license == license}
-                >
-                  {license}
-                </option>
-              </select>
+              />
             </div>
             <div>
               <label class="gf-label">License Link:</label>
@@ -193,14 +186,14 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
 
           <%!-- Row: Citation --%>
           <div class="mb-3">
-            <label class="gf-label">Citation (MLA format):</label>
-            <textarea
-              name={@form[:citation].name}
+            <.input
+              field={@form[:citation]}
+              type="textarea"
+              label="Citation (MLA format):"
               rows="4"
-              required
               placeholder="Enter full citation in MLA format"
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-            >{Phoenix.HTML.Form.input_value(@form, :citation)}</textarea>
+              required
+            />
             <p class="mt-1 text-xs text-gray-500">
               Use
               <a

--- a/v2/lib/gallformers_web/live/admin/taxonomy_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/taxonomy_live/form.ex
@@ -109,54 +109,32 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
 
         <.form for={@form} id="taxonomy-form" phx-change="validate" phx-submit="save">
           <div class="mb-3">
-            <label class="gf-label">Name:</label>
-            <input
+            <.input
+              field={@form[:name]}
               type="text"
-              name={@form[:name].name}
-              value={Phoenix.HTML.Form.input_value(@form, :name)}
+              label="Name:"
               placeholder="Enter taxonomy name"
               required
-              class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
             />
           </div>
 
           <div class="grid grid-cols-2 gap-4 mb-3">
             <div>
-              <label class="gf-label">Type:</label>
-              <select
-                name={@form[:type].name}
+              <.input
+                field={@form[:type]}
+                type="select"
+                label="Type:"
+                prompt="Select type"
+                options={[{"Family", "family"}, {"Genus", "genus"}, {"Section", "section"}]}
                 required
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">Select type</option>
-                <option
-                  value="family"
-                  selected={Phoenix.HTML.Form.input_value(@form, :type) == "family"}
-                >
-                  Family
-                </option>
-                <option
-                  value="genus"
-                  selected={Phoenix.HTML.Form.input_value(@form, :type) == "genus"}
-                >
-                  Genus
-                </option>
-                <option
-                  value="section"
-                  selected={Phoenix.HTML.Form.input_value(@form, :type) == "section"}
-                >
-                  Section
-                </option>
-              </select>
+              />
             </div>
             <div>
-              <label class="gf-label">Description:</label>
-              <input
+              <.input
+                field={@form[:description]}
                 type="text"
-                name={@form[:description].name}
-                value={Phoenix.HTML.Form.input_value(@form, :description)}
+                label="Description:"
                 placeholder="e.g., 'gall' or 'plant'"
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
               />
               <p class="mt-1 text-xs text-gray-500">For families: "gall" or "plant"</p>
             </div>
@@ -164,20 +142,13 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Form do
 
           <div class="mb-3">
             <%= if @parent_options != [] do %>
-              <label class="gf-label">Parent:</label>
-              <select
-                name={@form[:parent_id].name}
-                class="w-full px-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-gf-maroon focus:border-gf-maroon"
-              >
-                <option value="">Select parent (optional for families)</option>
-                <option
-                  :for={{label, id} <- @parent_options}
-                  value={id}
-                  selected={Phoenix.HTML.Form.input_value(@form, :parent_id) == id}
-                >
-                  {label}
-                </option>
-              </select>
+              <.input
+                field={@form[:parent_id]}
+                type="select"
+                label="Parent:"
+                prompt="Select parent (optional for families)"
+                options={@parent_options}
+              />
               <p class="mt-1 text-xs text-gray-500">
                 Genera belong to families or sections. Sections belong to families.
               </p>

--- a/v2/lib/gallformers_web/live/admin/taxonomy_live/index.ex
+++ b/v2/lib/gallformers_web/live/admin/taxonomy_live/index.ex
@@ -155,12 +155,15 @@ defmodule GallformersWeb.Admin.TaxonomyLive.Index do
                 phx-debounce="300"
               />
             </form>
-            <select name="type" phx-change="filter_type" class="gf-select !w-auto">
-              <option value="">All Types</option>
-              <option value="family" selected={@filter_type == "family"}>Families</option>
-              <option value="genus" selected={@filter_type == "genus"}>Genera</option>
-              <option value="section" selected={@filter_type == "section"}>Sections</option>
-            </select>
+            <form phx-change="filter_type">
+              <.input
+                type="select"
+                name="type"
+                prompt="All Types"
+                options={[{"Families", "family"}, {"Genera", "genus"}, {"Sections", "section"}]}
+                value={@filter_type}
+              />
+            </form>
           </div>
           <.link navigate={~p"/admin/taxonomy/new"} class="gf-btn gf-btn-primary">
             New Entry

--- a/v2/lib/gallformers_web/live/id_live.ex
+++ b/v2/lib/gallformers_web/live/id_live.ex
@@ -732,20 +732,16 @@ defmodule GallformersWeb.IDLive do
 
   defp detachable_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Detachable</label>
-      <form phx-change="change_filter" phx-value-filter="detachable">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any</option>
-          <option value="integral" selected={@value == "integral"}>Integral</option>
-          <option value="detachable" selected={@value == "detachable"}>Detachable</option>
-          <option value="both" selected={@value == "both"}>Both</option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="detachable">
+      <.input
+        type="select"
+        name="value"
+        label="Detachable"
+        prompt="Any"
+        options={[{"Integral", "integral"}, {"Detachable", "detachable"}, {"Both", "both"}]}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -755,20 +751,16 @@ defmodule GallformersWeb.IDLive do
 
   defp place_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Region</label>
-      <form phx-change="change_filter" phx-value-filter="place">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Region</option>
-          <option :for={place <- @places} value={place.code} selected={@value == place.code}>
-            {place.name}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="place">
+      <.input
+        type="select"
+        name="value"
+        label="Region"
+        prompt="Any Region"
+        options={Enum.map(@places, &{&1.name, &1.code})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -778,20 +770,16 @@ defmodule GallformersWeb.IDLive do
 
   defp family_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Family</label>
-      <form phx-change="change_filter" phx-value-filter="family">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Family</option>
-          <option :for={fam <- @families} value={fam.id} selected={@value == fam.id}>
-            {fam.name}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="family">
+      <.input
+        type="select"
+        name="value"
+        label="Family"
+        prompt="Any Family"
+        options={Enum.map(@families, &{&1.name, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -801,20 +789,16 @@ defmodule GallformersWeb.IDLive do
 
   defp color_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Color</label>
-      <form phx-change="change_filter" phx-value-filter="color">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Color</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.color}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="color">
+      <.input
+        type="select"
+        name="value"
+        label="Color"
+        prompt="Any Color"
+        options={Enum.map(@options, &{&1.color, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -824,20 +808,16 @@ defmodule GallformersWeb.IDLive do
 
   defp shape_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Shape</label>
-      <form phx-change="change_filter" phx-value-filter="shape">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Shape</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.shape}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="shape">
+      <.input
+        type="select"
+        name="value"
+        label="Shape"
+        prompt="Any Shape"
+        options={Enum.map(@options, &{&1.shape, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -847,20 +827,16 @@ defmodule GallformersWeb.IDLive do
 
   defp alignment_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Alignment</label>
-      <form phx-change="change_filter" phx-value-filter="alignment">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Alignment</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.alignment}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="alignment">
+      <.input
+        type="select"
+        name="value"
+        label="Alignment"
+        prompt="Any Alignment"
+        options={Enum.map(@options, &{&1.alignment, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -870,20 +846,16 @@ defmodule GallformersWeb.IDLive do
 
   defp form_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Form</label>
-      <form phx-change="change_filter" phx-value-filter="form">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Form</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.form}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="form">
+      <.input
+        type="select"
+        name="value"
+        label="Form"
+        prompt="Any Form"
+        options={Enum.map(@options, &{&1.form, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -893,20 +865,16 @@ defmodule GallformersWeb.IDLive do
 
   defp walls_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Walls</label>
-      <form phx-change="change_filter" phx-value-filter="walls">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Walls</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.walls}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="walls">
+      <.input
+        type="select"
+        name="value"
+        label="Walls"
+        prompt="Any Walls"
+        options={Enum.map(@options, &{&1.walls, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -916,20 +884,16 @@ defmodule GallformersWeb.IDLive do
 
   defp cells_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Cells</label>
-      <form phx-change="change_filter" phx-value-filter="cells">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Cells</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.cells}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="cells">
+      <.input
+        type="select"
+        name="value"
+        label="Cells"
+        prompt="Any Cells"
+        options={Enum.map(@options, &{&1.cells, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 
@@ -939,20 +903,16 @@ defmodule GallformersWeb.IDLive do
 
   defp season_filter(assigns) do
     ~H"""
-    <div class="mb-2">
-      <label class="block text-base font-medium text-gray-700 mb-1">Season</label>
-      <form phx-change="change_filter" phx-value-filter="season">
-        <select
-          name="value"
-          class="w-full px-3 py-2 border border-gray-300 rounded-md text-base focus:ring-gf-maroon focus:border-gf-maroon"
-        >
-          <option value="" selected={@value == nil}>Any Season</option>
-          <option :for={opt <- @options} value={opt.id} selected={@value == opt.id}>
-            {opt.season}
-          </option>
-        </select>
-      </form>
-    </div>
+    <form phx-change="change_filter" phx-value-filter="season">
+      <.input
+        type="select"
+        name="value"
+        label="Season"
+        prompt="Any Season"
+        options={Enum.map(@options, &{&1.season, &1.id})}
+        value={@value}
+      />
+    </form>
     """
   end
 


### PR DESCRIPTION
## Summary
- Migrate 10 filter selects in id_live.ex to use `.input` component
- Convert selects in article_admin, taxonomy, source, images, filter_terms, place, gall admin forms  
- Convert textareas in glossary, source, filter_terms, profile, images admin forms
- All forms now use consistent `.input` component for better maintainability

## Test plan
- [x] All 566 tests pass
- [x] `mix precommit` passes
- [ ] Manual test admin forms still submit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)