### PR TITLE
gallformers-zrgu: Migrate raw HTML checkboxes to .input component

### DIFF
--- a/v2/lib/gallformers_web/live/admin/article_admin_live.ex
+++ b/v2/lib/gallformers_web/live/admin/article_admin_live.ex
@@ -320,20 +320,7 @@ defmodule GallformersWeb.Admin.ArticleAdminLive do
                   />
                   <p class="mt-1 text-xs text-gray-500">Comma-separated list of tags</p>
                 </div>
-                <div class="flex items-center gap-2">
-                  <input type="hidden" name={@form[:is_published].name} value="false" />
-                  <input
-                    type="checkbox"
-                    name={@form[:is_published].name}
-                    id={@form[:is_published].id}
-                    value="true"
-                    checked={Phoenix.HTML.Form.input_value(@form, :is_published) == true}
-                    class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-                  />
-                  <label for={@form[:is_published].id} class="text-base text-gray-700">
-                    Published
-                  </label>
-                </div>
+                <.input type="checkbox" field={@form[:is_published]} label="Published" />
               </.form>
             <% else %>
               <%!-- Preview Tab --%>

--- a/v2/lib/gallformers_web/live/admin/gall_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/gall_live/form.ex
@@ -931,19 +931,11 @@ defmodule GallformersWeb.Admin.GallLive.Form do
 
           <%!-- Checkboxes --%>
           <div class="space-y-2 mb-4">
-            <label class="flex items-start gap-2 cursor-pointer">
-              <input type="hidden" name="species[datacomplete]" value="false" />
-              <input
-                type="checkbox"
-                name="species[datacomplete]"
-                value="true"
-                checked={@form[:datacomplete].value}
-                class="mt-0.5 rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-              />
-              <span class="text-sm text-gray-700">
-                All sources containing unique information relevant to this gall have been added and are reflected in its associated data. However, filter criteria may not be comprehensive in every field.
-              </span>
-            </label>
+            <.input
+              type="checkbox"
+              field={@form[:datacomplete]}
+              label="All sources containing unique information relevant to this gall have been added and are reflected in its associated data. However, filter criteria may not be comprehensive in every field."
+            />
 
             <%= if @mode == :edit do %>
               <label class="flex items-center gap-2 cursor-pointer">

--- a/v2/lib/gallformers_web/live/admin/host_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/host_live/form.ex
@@ -586,19 +586,11 @@ defmodule GallformersWeb.Admin.HostLive.Form do
 
           <%!-- Data Complete checkbox --%>
           <div class="space-y-2 mb-4">
-            <label class="flex items-start gap-2 cursor-pointer">
-              <input type="hidden" name="species[datacomplete]" value="false" />
-              <input
-                type="checkbox"
-                name="species[datacomplete]"
-                value="true"
-                checked={@form[:datacomplete].value}
-                class="mt-0.5 rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-              />
-              <span class="text-sm text-gray-700">
-                All galls known to occur on this plant have been added to the database, and can be filtered by Location and Detachable. However, sources and images for galls associated with this host may be incomplete or absent, and other filters may not have been entered comprehensively or at all.
-              </span>
-            </label>
+            <.input
+              type="checkbox"
+              field={@form[:datacomplete]}
+              label="All galls known to occur on this plant have been added to the database, and can be filtered by Location and Detachable. However, sources and images for galls associated with this host may be incomplete or absent, and other filters may not have been entered comprehensively or at all."
+            />
           </div>
 
           <%!-- Action buttons --%>

--- a/v2/lib/gallformers_web/live/admin/images_live.ex
+++ b/v2/lib/gallformers_web/live/admin/images_live.ex
@@ -324,20 +324,13 @@ defmodule GallformersWeb.AdminImagesLive do
                   value={@editing_image.caption || ""}
                 />
               </div>
-              <div class="flex items-center gap-2">
-                <input type="hidden" name="default" value="false" />
-                <input
-                  type="checkbox"
-                  name="default"
-                  value="true"
-                  checked={@editing_image.default}
-                  id="default-checkbox"
-                  class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-                />
-                <label for="default-checkbox" class="text-base text-gray-700">
-                  Set as default image
-                </label>
-              </div>
+              <.input
+                type="checkbox"
+                name="default"
+                checked={@editing_image.default}
+                id="default-checkbox"
+                label="Set as default image"
+              />
             </form>
           </:body>
           <:footer>

--- a/v2/lib/gallformers_web/live/admin/profile_live.ex
+++ b/v2/lib/gallformers_web/live/admin/profile_live.ex
@@ -196,17 +196,7 @@ defmodule GallformersWeb.Admin.ProfileLive do
 
             <%!-- Show on About Page --%>
             <div class="mb-3">
-              <input type="hidden" name={@form[:show_on_about].name} value="false" />
-              <label class="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  name={@form[:show_on_about].name}
-                  value="true"
-                  checked={Phoenix.HTML.Form.input_value(@form, :show_on_about) == true}
-                  class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-                />
-                <span class="text-sm text-gray-700">List me on the About page</span>
-              </label>
+              <.input type="checkbox" field={@form[:show_on_about]} label="List me on the About page" />
             </div>
 
             <%!-- Buttons --%>

--- a/v2/lib/gallformers_web/live/admin/source_live/form.ex
+++ b/v2/lib/gallformers_web/live/admin/source_live/form.ex
@@ -210,19 +210,11 @@ defmodule GallformersWeb.Admin.SourceLive.Form do
 
           <%!-- Row: Data Complete checkbox --%>
           <div class="mb-3">
-            <label class="flex items-center gap-2">
-              <input type="hidden" name={@form[:datacomplete].name} value="false" />
-              <input
-                type="checkbox"
-                name={@form[:datacomplete].name}
-                value="true"
-                checked={Phoenix.HTML.Form.input_value(@form, :datacomplete) == true}
-                class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-              />
-              <span class="text-sm text-gray-700">
-                All information from this source has been entered into the database
-              </span>
-            </label>
+            <.input
+              type="checkbox"
+              field={@form[:datacomplete]}
+              label="All information from this source has been entered into the database"
+            />
           </div>
 
           <%!-- Buttons --%>

--- a/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/add_from_source.ex
@@ -509,21 +509,11 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.AddFromSource do
                         </p>
                       </div>
 
-                      <div>
-                        <label class="flex items-center gap-2 cursor-pointer">
-                          <input type="hidden" name="species_source[useasdefault]" value="false" />
-                          <input
-                            type="checkbox"
-                            name="species_source[useasdefault]"
-                            value="true"
-                            checked={@form[:useasdefault].value in [1, "1", true, "true"]}
-                            class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-                          />
-                          <span class="text-sm text-gray-700">
-                            Use as default source for this species
-                          </span>
-                        </label>
-                      </div>
+                      <.input
+                        type="checkbox"
+                        field={@form[:useasdefault]}
+                        label="Use as default source for this species"
+                      />
 
                       <div class="flex justify-between items-center pt-4 border-t border-gray-200">
                         <div>

--- a/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
+++ b/v2/lib/gallformers_web/live/admin/species_source_live/quick_find.ex
@@ -342,25 +342,11 @@ defmodule GallformersWeb.Admin.SpeciesSourceLive.QuickFind do
                                 />
                               </div>
 
-                              <div>
-                                <label class="flex items-center gap-2 cursor-pointer">
-                                  <input
-                                    type="hidden"
-                                    name="species_source[useasdefault]"
-                                    value="false"
-                                  />
-                                  <input
-                                    type="checkbox"
-                                    name="species_source[useasdefault]"
-                                    value="true"
-                                    checked={@form[:useasdefault].value in [1, "1", true, "true"]}
-                                    class="rounded border-gray-300 text-gf-maroon focus:ring-gf-maroon"
-                                  />
-                                  <span class="text-sm text-gray-700">
-                                    Use as default source for this species
-                                  </span>
-                                </label>
-                              </div>
+                              <.input
+                                type="checkbox"
+                                field={@form[:useasdefault]}
+                                label="Use as default source for this species"
+                              />
 
                               <div class="flex justify-between items-center pt-3 border-t border-gray-200">
                                 <button

--- a/v2/lib/gallformers_web/live/id_live.ex
+++ b/v2/lib/gallformers_web/live/id_live.ex
@@ -923,17 +923,12 @@ defmodule GallformersWeb.IDLive do
     ~H"""
     <div class="mb-2">
       <form phx-change="change_filter" phx-value-filter="undescribed">
-        <label class="flex items-center gap-2 text-base cursor-pointer">
-          <input type="hidden" name="value" value="false" />
-          <input
-            type="checkbox"
-            name="value"
-            value="true"
-            checked={@value}
-            class="h-4 w-4 text-gf-maroon focus:ring-gf-maroon border-gray-300 rounded"
-          />
-          <span class="text-gray-700">Show only undescribed galls</span>
-        </label>
+        <.input
+          type="checkbox"
+          name="value"
+          checked={@value}
+          label="Show only undescribed galls"
+        />
       </form>
     </div>
     """


### PR DESCRIPTION
## Summary

- Migrate all form-bound raw HTML checkboxes to use the standardized `<.input type="checkbox">` component
- The component properly handles the hidden input for false values, ensuring unchecked state is correctly submitted
- 9 files updated, 83 lines removed due to simplified component usage

## Files Changed

| File | Checkbox |
|------|----------|
| profile_live.ex | show_on_about |
| gall_live/form.ex | datacomplete |
| host_live/form.ex | datacomplete |
| source_live/form.ex | datacomplete |
| article_admin_live.ex | is_published |
| quick_find.ex | useasdefault |
| add_from_source.ex | useasdefault |
| images_live.ex | default |
| id_live.ex | undescribed filter |

## Not Migrated

Checkboxes using `phx-click` for toggle actions (rather than form submission) were intentionally not migrated:
- `gall_live/form.ex`: undescribed toggle
- `form_components.ex`: add_alias_on_rename toggle

These don't need the hidden input pattern since they use event handlers rather than form submission.

## Test plan

- [x] `mix precommit` passes (566 tests, 0 failures)
- [ ] Manually verify checkboxes toggle correctly in admin forms
- [ ] Verify unchecked state is properly submitted (shows "false" in form data)

Closes gallformers-zrgu