### PR TITLE
Fix new gall form bug from duplicate key/value pair

### DIFF
--- a/lib/gallformers_web/live/admin/alias_handlers.ex
+++ b/lib/gallformers_web/live/admin/alias_handlers.ex
@@ -37,11 +37,11 @@ defmodule GallformersWeb.Admin.AliasHandlers do
   end
 
   @doc """
-  Handles the alias type select changing. The select is inside the parent form, so
-  Phoenix LiveView serializes it as a form field — `name="value"` on the select
-  produces `%{"value" => type}` in the payload.
+  Handles the alias type select changing. The select uses `name="alias_type"` (not
+  `name="value"`) to avoid colliding with other `name="value"` selects in the same
+  parent form when Phoenix LV serializes the full form on phx-change.
   """
-  def handle_update_new_alias_type(socket, %{"value" => type}) do
+  def handle_update_new_alias_type(socket, %{"alias_type" => type}) do
     assign(socket, new_alias_type: type)
   end
 

--- a/lib/gallformers_web/live/admin/form_components.ex
+++ b/lib/gallformers_web/live/admin/form_components.ex
@@ -201,7 +201,7 @@ defmodule GallformersWeb.Admin.FormComponents do
               </td>
               <td class="px-3 py-1.5">
                 <select
-                  name="value"
+                  name="alias_type"
                   phx-change="update_new_alias_type"
                   class="gf-select text-sm"
                 >

--- a/test/gallformers_web/live/admin/gall_live/form_test.exs
+++ b/test/gallformers_web/live/admin/gall_live/form_test.exs
@@ -244,7 +244,7 @@ defmodule GallformersWeb.Admin.GallLive.FormTest do
 
       render_hook(view, "update_new_alias_name", %{"value" => "Foobar synonym"})
 
-      html = render_change(view, "update_new_alias_type", %{"value" => "scientific"})
+      html = render_change(view, "update_new_alias_type", %{"alias_type" => "scientific"})
 
       assert html =~ ~s(value="Foobar synonym")
       assert html =~ ~r/<option[^>]*value="scientific"[^>]*selected/

--- a/test/gallformers_web/live/admin/host_live/form_test.exs
+++ b/test/gallformers_web/live/admin/host_live/form_test.exs
@@ -289,9 +289,7 @@ defmodule GallformersWeb.Admin.HostLive.FormTest do
       # Type a name first
       render_hook(view, "update_new_alias_name", %{"value" => "Foobar synonym"})
 
-      # Then change the type select. The select has name="value" so Phoenix LV
-      # serializes it as %{"value" => "scientific"} from the form payload.
-      html = render_change(view, "update_new_alias_type", %{"value" => "scientific"})
+      html = render_change(view, "update_new_alias_type", %{"alias_type" => "scientific"})
 
       # Name must be preserved (bug: previously cleared when type changed).
       assert html =~ ~s(value="Foobar synonym")


### PR DESCRIPTION
No matter how many way's I try I cannot get the gall form to submit. I always get the error "_detachable must be one of: unknown, integral, detachable, both_"

<img width="1235" height="811" alt="image" src="https://github.com/user-attachments/assets/b92d562b-4b8c-496d-929e-eb941b109668" />

In the new gall form I believe the '_Detachable_' dropdown silently stopped working on May 15, 2026 in [`c3878f2d`](https://github.com/jeffdc/gallformers/commit/c3878f2d). That commit added `name="value"` to the alias type select in `alias_editor` to fix a crash when switching to "_Scientific Synonym_", but the alias editor is rendered inside the same `<.form>` as the detachable select, which also uses `name="value"`. When the '_Detachable_' dropdown fires `phx-change` the full form serializes. When Plug parses an HTTP form body, it reads key/value pairs sequentially. If the same key appears twice, which happens here because both selects have `name="value"`, it keeps the last one (e.g. _Abundance = "common"_) and discards the first, the required _Detachable_ value. The form then fails `validate_inclusion` on save with "detachable must be one of: unknown, integral, detachable, both".

All I did here was rename the alias type select to `name="alias_type"` and update the handler pattern to match. I also updated the tests, which pass. But when attempting to run the repo locally the site UI is not functional enough to test without a full database.

Let me know if there are any problems or I'm offbase, I'm not an elixir dev, just trying to help.