### PR TITLE
fix broken guide link

### DIFF
--- a/lib/gallformers_web/live/admin/dashboard_live.ex
+++ b/lib/gallformers_web/live/admin/dashboard_live.ex
@@ -28,7 +28,7 @@ defmodule GallformersWeb.Admin.DashboardLive do
       <div class="relative">
         <p class="text-sm text-gray-500 absolute right-0 top-0.5">
           <a
-            href="https://github.com/jeffdc/gallformers/blob/main/docs/ops/admin-onboarding.md"
+            href="https://github.com/jeffdc/gallformers/blob/main/docs/domain/admin-onboarding.md"
             target="_blank"
             class="text-gf-maroon hover:underline"
           >


### PR DESCRIPTION
The UI guide link goes to a dead GH file:

- https://github.com/jeffdc/gallformers/blob/main/docs/ops/admin-onboarding.md

<img width="555" height="251" alt="image" src="https://github.com/user-attachments/assets/eb0b0087-a73b-4c74-b972-5b3b8835ac7c" />

<img width="1429" height="470" alt="image" src="https://github.com/user-attachments/assets/ec5f15d7-bdbb-4882-9d28-673209a547dd" />

I changed it to this link:

- https://github.com/jeffdc/gallformers/blob/main/docs/domain/admin-onboarding.md