### PR TITLE
Offset anchor scroll for sticky header and disclaim gall range maps

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -132,6 +132,9 @@ html {
   font-weight: 400; /* Normal weight for better readability */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Keep #anchor targets (e.g. glossary term links) clear of the sticky
+     site header, which is ~78px tall (70px logo + py-1). */
+  scroll-padding-top: 5.5rem;
 }
 
 /* Restore heading sizes stripped by Tailwind preflight */

--- a/lib/gallformers_web/live/gall_live.ex
+++ b/lib/gallformers_web/live/gall_live.ex
@@ -502,6 +502,10 @@ defmodule GallformersWeb.GallLive do
                 >
                   Range unknown — only genus-level host data available.
                 </p>
+                <.alert :if={not @only_placeholder_hosts?} variant="info" class="mt-1 mb-2">
+                  Not an occurrence map: this shows where this gall's hosts grow. In most cases the
+                  gall has not been documented throughout this area.
+                </.alert>
                 <.range_map
                   :if={not @only_placeholder_hosts?}
                   id="gall-range-map"

--- a/test/gallformers_web/live/gall_live_test.exs
+++ b/test/gallformers_web/live/gall_live_test.exs
@@ -94,6 +94,21 @@ defmodule GallformersWeb.GallLiveTest do
       end
     end
 
+    test "disclaims the range map as a host-range estimate", %{conn: conn} do
+      galls = Galls.list_galls()
+
+      if length(galls) > 0 do
+        gall = hd(galls)
+        {:ok, view, html} = live(conn, ~p"/gall/#{gall.id}")
+
+        # The disclaimer accompanies the map, so only assert it when a map rendered
+        if has_element?(view, "#gall-range-map") do
+          assert html =~ "Not an occurrence map"
+          assert html =~ "has not been documented throughout this area"
+        end
+      end
+    end
+
     test "displays completion status badge", %{conn: conn} do
       galls = Galls.list_galls()
 


### PR DESCRIPTION
Two small independent fixes.

### #566 — Glossary links go one entry too low

`/glossary#term` links scrolled the target row flush with the top of the viewport, tucking it under the sticky site header.

Added `scroll-padding-top: 5.5rem` to `html` in `assets/css/app.css`. This is the native CSS mechanism for exactly this problem, so it fixes in-page `#anchor` navigation site-wide rather than just the glossary.

The 88px value leaves ~10px of clearance under the header, which is ~78px tall (70px logo + `py-1`). That matches the figure already recorded in `assets/js/hooks/scroll_to_couplet.js` ("Account for sticky header (~78px)").

No interaction with the existing scroll code: `scroll_to_couplet` uses `window.scrollTo`, which `scroll-padding` does not affect, and the only `scrollIntoView` call (`typeahead.js`) scrolls inside its own dropdown container rather than the document.

### #560 — Disclaim host range as potential gall range

The "this is computed from host ranges" caveat existed only inside the `info_tip` tooltip next to **Possible Range**, so it was easy to miss entirely.

Added an always-visible `<.alert variant="info">` above the range map on the gall page:

> Not an occurrence map: this shows where this gall's hosts grow. In most cases the gall has not been documented throughout this area.

Reuses the existing `alert` component. The `info_tip` is unchanged and still carries the fuller explanation. The alert is suppressed when `@only_placeholder_hosts?` is true, since that branch renders the "Range unknown" note instead of a map.

This does not address the longer-term goal in #560 of showing type locality / literature locations / iNat observations — that still depends on the new data layer.

### Verification

- `mix compile --warnings-as-errors` clean
- `mix format --check-formatted` and `mix credo --strict` clean on changed files
- Full suite: 2144 tests, 0 failures
- One new test in `gall_live_test.exs` covering the disclaimer

The CSS change has not been eyeballed in a browser — Playwright won't install under WSL1 here and the Chrome extension wasn't connected. The value is derived from the markup and corroborated by the existing hook comment, but it's worth a quick look before merge.

Closes #566
Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
