### PR TITLE
Persist key authors from the admin form

### DIFF
--- a/lib/gallformers_web/live/admin/key_live/form.ex
+++ b/lib/gallformers_web/live/admin/key_live/form.ex
@@ -124,14 +124,10 @@ defmodule GallformersWeb.Admin.KeyLive.Form do
 
   @impl true
   def handle_event("save", params, socket) do
-    key_params = Map.get(params, "key", %{})
-
-    # Merge couplets from JSON input into params
     key_params =
-      case parse_json_couplets(socket.assigns.json_input) do
-        {:ok, couplets_json} -> Map.put(key_params, "couplets", couplets_json)
-        _ -> key_params
-      end
+      params
+      |> Map.get("key", %{})
+      |> merge_json_only_fields(socket.assigns.json_input)
 
     handle_save(%{"key" => key_params}, socket)
   end
@@ -225,21 +221,27 @@ defmodule GallformersWeb.Admin.KeyLive.Form do
     {:noreply, socket}
   end
 
-  defp parse_json_couplets(json_text) do
+  # `couplets` and `authors` have no inputs of their own in the form, so the
+  # browser never posts them. Both are merged in from the JSON textarea on save,
+  # otherwise the changeset never casts them and the stored values go stale.
+  defp merge_json_only_fields(key_params, json_text) do
     case Jason.decode(json_text) do
       {:ok, data} when is_map(data) ->
-        couplets = data["couplets"]
-
-        if is_map(couplets) and map_size(couplets) > 0 do
-          {:ok, Jason.encode!(couplets)}
-        else
-          :error
-        end
+        key_params
+        |> maybe_put_couplets(data["couplets"])
+        |> Map.put("authors", Jason.encode!(data["authors"] || []))
 
       _ ->
-        :error
+        key_params
     end
   end
+
+  defp maybe_put_couplets(key_params, couplets)
+       when is_map(couplets) and map_size(couplets) > 0 do
+    Map.put(key_params, "couplets", Jason.encode!(couplets))
+  end
+
+  defp maybe_put_couplets(key_params, _couplets), do: key_params
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/gallformers_web/live/admin/key_live/form.ex
+++ b/lib/gallformers_web/live/admin/key_live/form.ex
@@ -227,21 +227,21 @@ defmodule GallformersWeb.Admin.KeyLive.Form do
   defp merge_json_only_fields(key_params, json_text) do
     case Jason.decode(json_text) do
       {:ok, data} when is_map(data) ->
-        key_params
-        |> maybe_put_couplets(data["couplets"])
-        |> Map.put("authors", Jason.encode!(data["authors"] || []))
+        key_params =
+          case data["couplets"] do
+            c when is_map(c) and map_size(c) > 0 ->
+              Map.put(key_params, "couplets", Jason.encode!(c))
+
+            _ ->
+              key_params
+          end
+
+        Map.put(key_params, "authors", Jason.encode!(data["authors"] || []))
 
       _ ->
         key_params
     end
   end
-
-  defp maybe_put_couplets(key_params, couplets)
-       when is_map(couplets) and map_size(couplets) > 0 do
-    Map.put(key_params, "couplets", Jason.encode!(couplets))
-  end
-
-  defp maybe_put_couplets(key_params, _couplets), do: key_params
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/test/gallformers_web/live/admin/key_live/form_test.exs
+++ b/test/gallformers_web/live/admin/key_live/form_test.exs
@@ -1,0 +1,169 @@
+defmodule GallformersWeb.Admin.KeyLive.FormTest do
+  @moduledoc """
+  Tests for saving key metadata from the admin form.
+
+  `authors` and `couplets` have no inputs of their own in the form, so they are
+  only persisted if the save handler merges them in from the JSON textarea.
+  """
+  use GallformersWeb.ConnCase, async: true
+
+  import ExUnit.CaptureLog
+  import Phoenix.LiveViewTest
+
+  alias Gallformers.Accounts.Auth0User
+  alias Gallformers.Keys
+
+  @couplets %{
+    "1" => %{
+      "leads" => [
+        %{"text" => "Wings fully developed.", "destination" => nil},
+        %{"text" => "Wings reduced or absent.", "destination" => nil}
+      ]
+    }
+  }
+
+  defp setup_admin_session(conn) do
+    user = %Auth0User{
+      id: "test-admin-id",
+      email: "admin@test.com",
+      name: "Test Admin",
+      nickname: nil,
+      picture: nil,
+      roles: ["admin"]
+    }
+
+    conn
+    |> init_test_session(%{})
+    |> put_session(:current_user, user)
+    |> put_session(:db_display_name, "Test User")
+  end
+
+  defp key_json(attrs) do
+    Map.merge(
+      %{
+        "title" => "Key to parasitic wasps",
+        "slug" => "key-to-parasitic-wasps",
+        "version" => "2026-02-05",
+        "couplets" => @couplets
+      },
+      attrs
+    )
+    |> Jason.encode!()
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: setup_admin_session(conn)}
+  end
+
+  describe "authors" do
+    test "are persisted when editing an existing key", %{conn: conn} do
+      {:ok, key} =
+        Keys.create_key(%{
+          title: "Key to parasitic wasps",
+          slug: "key-to-parasitic-wasps",
+          version: "2026-02-01",
+          couplets: @couplets
+        })
+
+      assert key.authors == []
+
+      json = key_json(%{"authors" => ["Louis Nastasi"]})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/keys/#{key.id}")
+
+      capture_log(fn ->
+        render_hook(view, "json_changed", %{"value" => json})
+        view |> form("#key-form") |> render_submit()
+      end)
+
+      assert Keys.get_key!(key.id).authors == ["Louis Nastasi"]
+    end
+
+    test "are persisted when creating a new key", %{conn: conn} do
+      json = key_json(%{"authors" => ["Louis Nastasi"]})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/keys/new")
+
+      capture_log(fn ->
+        render_hook(view, "json_changed", %{"value" => json})
+        view |> form("#key-form") |> render_submit()
+      end)
+
+      assert {:ok, %{authors: ["Louis Nastasi"]}} = Keys.get_key("key-to-parasitic-wasps")
+    end
+
+    test "survive a save that does not touch the JSON textarea", %{conn: conn} do
+      {:ok, key} =
+        Keys.create_key(%{
+          title: "Key to parasitic wasps",
+          slug: "key-to-parasitic-wasps",
+          version: "2026-02-01",
+          authors: ["Louis Nastasi"],
+          couplets: @couplets
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/keys/#{key.id}")
+
+      capture_log(fn ->
+        view |> form("#key-form", key: %{subtitle: "Hymenoptera: Cynipini"}) |> render_submit()
+      end)
+
+      reloaded = Keys.get_key!(key.id)
+      assert reloaded.authors == ["Louis Nastasi"]
+      assert reloaded.subtitle == "Hymenoptera: Cynipini"
+    end
+
+    test "are cleared when removed from the JSON", %{conn: conn} do
+      {:ok, key} =
+        Keys.create_key(%{
+          title: "Key to parasitic wasps",
+          slug: "key-to-parasitic-wasps",
+          version: "2026-02-01",
+          authors: ["Louis Nastasi"],
+          couplets: @couplets
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/keys/#{key.id}")
+
+      json = key_json(%{"authors" => []})
+
+      capture_log(fn ->
+        render_hook(view, "json_changed", %{"value" => json})
+        view |> form("#key-form") |> render_submit()
+      end)
+
+      assert Keys.get_key!(key.id).authors == []
+    end
+  end
+
+  describe "couplets" do
+    test "are still persisted from the JSON textarea", %{conn: conn} do
+      {:ok, key} =
+        Keys.create_key(%{
+          title: "Key to parasitic wasps",
+          slug: "key-to-parasitic-wasps",
+          version: "2026-02-01",
+          couplets: @couplets
+        })
+
+      updated_couplets =
+        Map.put(@couplets, "2", %{
+          "leads" => [
+            %{"text" => "Metafemur toothed.", "destination" => nil},
+            %{"text" => "Metafemur not toothed.", "destination" => nil}
+          ]
+        })
+
+      json = key_json(%{"couplets" => updated_couplets})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/keys/#{key.id}")
+
+      capture_log(fn ->
+        render_hook(view, "json_changed", %{"value" => json})
+        view |> form("#key-form") |> render_submit()
+      end)
+
+      assert map_size(Keys.get_key!(key.id).couplets) == 2
+    end
+  end
+end


### PR DESCRIPTION
Fixes #568.

## Problem

Saving a key from the admin form reports success but never writes `authors`. The field has no rendered input on the form, so the browser never posts `key[authors]`, and `Key.changeset/2` leaves the column untouched. The value is parsed out of the JSON textarea into the changeset for display (`form.ex:165`), which is why it still looks right until you reload.

`couplets` is in the same position — no input of its own — and was already merged back in from the JSON textarea on save. `authors` was missed.

## Change

Merge both JSON-only fields in one pass in `handle_event("save", ...)`, replacing `parse_json_couplets/1` with `merge_json_only_fields/2`. This keeps the JSON textarea as the single source of truth for these fields rather than adding a second place to edit attribution.

Behavior is unchanged for every other field, and for couplets: an unparseable textarea still falls through and posts the form params as-is.

Since `to_json_map/1` already writes `authors` back into the textarea on edit, an untouched form re-saves the same value rather than blanking it.

## Tests

New `test/gallformers_web/live/admin/key_live/form_test.exs`:

- authors persist when editing an existing key
- authors persist when creating a new key
- authors survive a save that does not touch the JSON textarea (round-trip guard)
- authors are cleared when removed from the JSON (explicit intent still works)
- couplets are still persisted from the JSON textarea (regression guard for the refactor)

The three authors-writing tests fail against `main` and pass with this change. Full suite: 2148 tests, 0 failures. `mix format --check-formatted`, `mix compile --warnings-as-errors` and `mix credo --strict` are clean on both changed files.

> Note: `mix precommit`'s global `format_check` also reports pre-existing drift in `ingestion_pipeline/stages/assemble.ex`, `stages/metadata.ex` and `admin/images_live.ex`. That's a local Elixir 1.18 vs CI 1.19 formatter difference, unrelated to this PR — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)