### PR TITLE
Show galler genus to host genus mappings

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -684,6 +684,11 @@ a.gf-btn-primary:hover {
   font-size: 1rem;
 }
 
+/* Button shapes */
+.gf-btn-pill {
+  border-radius: 9999px;
+}
+
 /* ============================================
    Admin Info Banner
    ============================================ */

--- a/lib/gallformers/taxonomy.ex
+++ b/lib/gallformers/taxonomy.ex
@@ -198,6 +198,7 @@ defmodule Gallformers.Taxonomy do
   # Delegated to Taxonomy.Tree — Cross-domain Queries
   # =====================================================================
 
+  defdelegate list_associated_genera(genus_id, taxoncode), to: Tree
   defdelegate list_gall_families_for_host(host_id), to: Tree
   defdelegate list_gall_families_for_host_genus(host_genus_id), to: Tree
   defdelegate list_sections_with_details(), to: Tree

--- a/lib/gallformers/taxonomy/tree.ex
+++ b/lib/gallformers/taxonomy/tree.ex
@@ -1160,11 +1160,15 @@ defmodule Gallformers.Taxonomy.Tree do
         name: related.name,
         focal_species_count: count(field(association, ^focal_key), :distinct),
         association_count: count(association.id, :distinct),
-        focal_species_ids: fragment("array_agg(DISTINCT ?)", field(association, ^focal_key))
+        focal_species_ids:
+          fragment(
+            "array_agg(DISTINCT ? ORDER BY ?)",
+            field(association, ^focal_key),
+            field(association, ^focal_key)
+          )
       }
     )
     |> Repo.all()
-    |> Enum.map(&Map.update!(&1, :focal_species_ids, fn ids -> Enum.sort(ids) end))
   end
 
   @doc """

--- a/lib/gallformers/taxonomy/tree.ex
+++ b/lib/gallformers/taxonomy/tree.ex
@@ -1126,6 +1126,63 @@ defmodule Gallformers.Taxonomy.Tree do
   # =====================================================================
 
   @doc """
+  Lists genera from the opposite domain associated with species in a genus.
+
+  For a gall genus this returns host genera; for a plant genus it returns
+  gall-former genera. Each result includes the focal species IDs so genus
+  pages can filter their species table without another query.
+  """
+  @spec list_associated_genera(integer(), String.t()) :: [map()]
+  def list_associated_genera(genus_id, taxoncode) when taxoncode in ["gall", "plant"] do
+    {focal_join, related_join, focal_column} =
+      if taxoncode == "gall" do
+        {
+          "JOIN gallhost gh ON gh.gall_species_id = focal.id",
+          "JOIN species_taxonomy related_st ON related_st.species_id = gh.host_species_id",
+          "gh.gall_species_id"
+        }
+      else
+        {
+          "JOIN gallhost gh ON gh.host_species_id = focal.id",
+          "JOIN species_taxonomy related_st ON related_st.species_id = gh.gall_species_id",
+          "gh.host_species_id"
+        }
+      end
+
+    query = """
+    SELECT related.id,
+           related.name,
+           COUNT(DISTINCT #{focal_column}) AS focal_species_count,
+           COUNT(DISTINCT gh.id) AS association_count,
+           ARRAY_AGG(DISTINCT #{focal_column} ORDER BY #{focal_column}) AS focal_species_ids
+    FROM species_taxonomy focal_st
+    JOIN species focal ON focal.id = focal_st.species_id AND focal.taxoncode = $2
+    #{focal_join}
+    #{related_join}
+    JOIN taxonomy related ON related.id = related_st.taxonomy_id AND related.type = 'genus'
+    WHERE focal_st.taxonomy_id = $1::bigint
+    GROUP BY related.id, related.name
+    ORDER BY related.name
+    """
+
+    case Repo.query(query, [genus_id, taxoncode]) do
+      {:ok, %{rows: rows}} ->
+        Enum.map(rows, fn [id, name, focal_count, association_count, focal_ids] ->
+          %{
+            id: id,
+            name: name,
+            focal_species_count: focal_count,
+            association_count: association_count,
+            focal_species_ids: focal_ids
+          }
+        end)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  @doc """
   Lists families for galls that occur on a given host.
   """
   @spec list_gall_families_for_host(integer()) :: [map()]

--- a/lib/gallformers/taxonomy/tree.ex
+++ b/lib/gallformers/taxonomy/tree.ex
@@ -8,6 +8,7 @@ defmodule Gallformers.Taxonomy.Tree do
 
   require Logger
   import Ecto.Query
+  alias Gallformers.Galls.GallHost
   alias Gallformers.Repo
   alias Gallformers.Species.Species
   alias Gallformers.TaxonName
@@ -1133,53 +1134,37 @@ defmodule Gallformers.Taxonomy.Tree do
   pages can filter their species table without another query.
   """
   @spec list_associated_genera(integer(), String.t()) :: [map()]
-  def list_associated_genera(genus_id, taxoncode) when taxoncode in ["gall", "plant"] do
-    {focal_join, related_join, focal_column} =
-      if taxoncode == "gall" do
-        {
-          "JOIN gallhost gh ON gh.gall_species_id = focal.id",
-          "JOIN species_taxonomy related_st ON related_st.species_id = gh.host_species_id",
-          "gh.gall_species_id"
-        }
-      else
-        {
-          "JOIN gallhost gh ON gh.host_species_id = focal.id",
-          "JOIN species_taxonomy related_st ON related_st.species_id = gh.gall_species_id",
-          "gh.host_species_id"
-        }
-      end
+  def list_associated_genera(genus_id, "gall") do
+    do_list_associated_genera(genus_id, "gall", :gall_species_id, :host_species_id)
+  end
 
-    query = """
-    SELECT related.id,
-           related.name,
-           COUNT(DISTINCT #{focal_column}) AS focal_species_count,
-           COUNT(DISTINCT gh.id) AS association_count,
-           ARRAY_AGG(DISTINCT #{focal_column} ORDER BY #{focal_column}) AS focal_species_ids
-    FROM species_taxonomy focal_st
-    JOIN species focal ON focal.id = focal_st.species_id AND focal.taxoncode = $2
-    #{focal_join}
-    #{related_join}
-    JOIN taxonomy related ON related.id = related_st.taxonomy_id AND related.type = 'genus'
-    WHERE focal_st.taxonomy_id = $1::bigint
-    GROUP BY related.id, related.name
-    ORDER BY related.name
-    """
+  def list_associated_genera(genus_id, "plant") do
+    do_list_associated_genera(genus_id, "plant", :host_species_id, :gall_species_id)
+  end
 
-    case Repo.query(query, [genus_id, taxoncode]) do
-      {:ok, %{rows: rows}} ->
-        Enum.map(rows, fn [id, name, focal_count, association_count, focal_ids] ->
-          %{
-            id: id,
-            name: name,
-            focal_species_count: focal_count,
-            association_count: association_count,
-            focal_species_ids: focal_ids
-          }
-        end)
-
-      {:error, _} ->
-        []
-    end
+  defp do_list_associated_genera(genus_id, taxoncode, focal_key, related_key) do
+    from(focal_link in "species_taxonomy",
+      join: focal in Species,
+      on: focal.id == focal_link.species_id and focal.taxoncode == ^taxoncode,
+      join: association in GallHost,
+      on: field(association, ^focal_key) == focal.id,
+      join: related_link in "species_taxonomy",
+      on: related_link.species_id == field(association, ^related_key),
+      join: related in Taxonomy,
+      on: related.id == related_link.taxonomy_id and related.type == "genus",
+      where: focal_link.taxonomy_id == ^genus_id,
+      group_by: [related.id, related.name],
+      order_by: related.name,
+      select: %{
+        id: related.id,
+        name: related.name,
+        focal_species_count: count(field(association, ^focal_key), :distinct),
+        association_count: count(association.id, :distinct),
+        focal_species_ids: fragment("array_agg(DISTINCT ?)", field(association, ^focal_key))
+      }
+    )
+    |> Repo.all()
+    |> Enum.map(&Map.update!(&1, :focal_species_ids, fn ids -> Enum.sort(ids) end))
   end
 
   @doc """

--- a/lib/gallformers_web/components/core_components.ex
+++ b/lib/gallformers_web/components/core_components.ex
@@ -124,11 +124,17 @@ defmodule GallformersWeb.CoreComponents do
     * `ghost` - Transparent background, maroon text
     * `soft` - Light maroon background, maroon text (default)
 
+  ## Shapes
+
+    * `rect` - Rounded rectangle (default)
+    * `pill` - Fully rounded pill
+
   ## Examples
 
       <.button>Send!</.button>
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button variant="danger">Delete</.button>
+      <.button shape="pill">Filter</.button>
       <.button navigate={~p"/"}>Home</.button>
       <.button type="submit" variant="primary">Save</.button>
   """
@@ -139,6 +145,7 @@ defmodule GallformersWeb.CoreComponents do
   attr :class, :any, default: nil
   attr :variant, :string, default: "soft", values: ~w(primary secondary danger warning ghost soft)
   attr :size, :string, default: "md", values: ~w(sm md lg)
+  attr :shape, :string, default: "rect", values: ~w(rect pill)
   slot :inner_block, required: true
 
   def button(%{rest: rest} = assigns) do
@@ -157,20 +164,26 @@ defmodule GallformersWeb.CoreComponents do
       "lg" => "gf-btn-lg"
     }
 
+    shapes = %{
+      "rect" => nil,
+      "pill" => "gf-btn-pill"
+    }
+
     assigns =
       assigns
       |> assign(:variant_class, Map.fetch!(variants, assigns.variant))
       |> assign(:size_class, Map.fetch!(sizes, assigns.size))
+      |> assign(:shape_class, Map.fetch!(shapes, assigns.shape))
 
     if rest[:href] || rest[:navigate] || rest[:patch] do
       ~H"""
-      <.link class={["gf-btn", @variant_class, @size_class, @class]} {@rest}>
+      <.link class={["gf-btn", @variant_class, @size_class, @shape_class, @class]} {@rest}>
         {render_slot(@inner_block)}
       </.link>
       """
     else
       ~H"""
-      <button class={["gf-btn", @variant_class, @size_class, @class]} {@rest}>
+      <button class={["gf-btn", @variant_class, @size_class, @shape_class, @class]} {@rest}>
         {render_slot(@inner_block)}
       </button>
       """

--- a/lib/gallformers_web/live/genus_live.ex
+++ b/lib/gallformers_web/live/genus_live.ex
@@ -358,24 +358,28 @@ defmodule GallformersWeb.GenusLive do
                     phx-click="toggle_related_genera"
                     aria-expanded="false"
                     aria-controls="related-genera-filters"
-                    class="w-full justify-between gap-4 rounded-lg px-4 py-3 text-left shadow-sm hover:border-gf-maroon hover:bg-gf-cream"
+                    class="w-full text-left shadow-sm"
                   >
-                    <span class="flex min-w-0 items-center gap-2">
-                      <.icon name="ph-arrows-left-right" class="size-5 shrink-0" />
-                      <span class="font-medium">{@related_heading}</span>
-                      <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
-                        {length(@related_genera)}
+                    <span class="flex w-full items-center justify-between gap-4">
+                      <span class="flex min-w-0 items-center gap-2">
+                        <.icon name="ph-arrows-left-right" class="size-5 shrink-0" />
+                        <span class="font-medium">{@related_heading}</span>
+                        <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                          {length(@related_genera)}
+                        </span>
+                        <span :if={@selected_related_genus} class="truncate text-sm text-gray-600">
+                          — filtered by
+                          <.taxon_name
+                            name={
+                              Enum.find(@related_genera, &(&1.id == @selected_related_genus)).name
+                            }
+                            rank="genus"
+                          />
+                        </span>
                       </span>
-                      <span :if={@selected_related_genus} class="truncate text-sm text-gray-600">
-                        — filtered by
-                        <.taxon_name
-                          name={Enum.find(@related_genera, &(&1.id == @selected_related_genus)).name}
-                          rank="genus"
-                        />
+                      <span class="flex shrink-0 items-center gap-1 text-sm">
+                        Show filters <.icon name="ph-caret-down" class="size-4" />
                       </span>
-                    </span>
-                    <span class="flex shrink-0 items-center gap-1 text-sm">
-                      Show filters <.icon name="ph-caret-down" class="size-4" />
                     </span>
                   </.button>
 
@@ -412,10 +416,11 @@ defmodule GallformersWeb.GenusLive do
                         type="button"
                         variant={if is_nil(@selected_related_genus), do: "primary", else: "secondary"}
                         size="sm"
+                        shape="pill"
                         phx-click="filter_related_genus"
                         phx-value-id="all"
                         aria-pressed={is_nil(@selected_related_genus)}
-                        class="gap-2 rounded-full"
+                        class="gap-2"
                       >
                         All species <span class="text-xs opacity-80">{@total_species_count}</span>
                       </.button>
@@ -428,11 +433,12 @@ defmodule GallformersWeb.GenusLive do
                             else: "secondary"
                         }
                         size="sm"
+                        shape="pill"
                         phx-click="filter_related_genus"
                         phx-value-id={genus.id}
                         aria-pressed={@selected_related_genus == genus.id}
                         title={"#{genus.association_count} species-to-species associations"}
-                        class="gap-2 rounded-full hover:border-gf-maroon"
+                        class="gap-2"
                       >
                         <.taxon_name name={genus.name} rank="genus" />
                         <span class={[
@@ -456,7 +462,7 @@ defmodule GallformersWeb.GenusLive do
                         size="sm"
                         phx-click="filter_related_genus"
                         phx-value-id="all"
-                        class="ml-1 px-1 underline hover:no-underline"
+                        class="ml-1 underline hover:no-underline"
                       >
                         Clear filter
                       </.button>

--- a/lib/gallformers_web/live/genus_live.ex
+++ b/lib/gallformers_web/live/genus_live.ex
@@ -351,13 +351,14 @@ defmodule GallformersWeb.GenusLive do
             <div class="mt-6">
               <%= if @total_species_count > 0 do %>
                 <div :if={@related_genera != []} class="mb-6">
-                  <button
+                  <.button
                     :if={!@show_related_genera}
                     type="button"
+                    variant="secondary"
                     phx-click="toggle_related_genera"
                     aria-expanded="false"
                     aria-controls="related-genera-filters"
-                    class="w-full flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left text-gf-maroon shadow-sm hover:border-gf-maroon hover:bg-gf-cream transition-colors"
+                    class="w-full justify-between gap-4 rounded-lg px-4 py-3 text-left shadow-sm hover:border-gf-maroon hover:bg-gf-cream"
                   >
                     <span class="flex min-w-0 items-center gap-2">
                       <.icon name="ph-arrows-left-right" class="size-5 shrink-0" />
@@ -376,7 +377,7 @@ defmodule GallformersWeb.GenusLive do
                     <span class="flex shrink-0 items-center gap-1 text-sm">
                       Show filters <.icon name="ph-caret-down" class="size-4" />
                     </span>
-                  </button>
+                  </.button>
 
                   <.card
                     :if={@show_related_genera}
@@ -385,15 +386,17 @@ defmodule GallformersWeb.GenusLive do
                     id="related-genera-filters"
                   >
                     <:actions>
-                      <button
+                      <.button
                         type="button"
+                        variant="ghost"
+                        size="sm"
                         phx-click="toggle_related_genera"
                         aria-expanded="true"
                         aria-controls="related-genera-filters"
-                        class="inline-flex items-center gap-1 text-sm text-gf-maroon hover:underline"
+                        class="gap-1 hover:underline"
                       >
                         Hide <.icon name="ph-caret-up" class="size-4" />
-                      </button>
+                      </.button>
                     </:actions>
                     <p class="text-sm text-gray-600 mb-4">
                       Select a genus to filter the species list below. Counts show how many species
@@ -405,35 +408,31 @@ defmodule GallformersWeb.GenusLive do
                       role="group"
                       aria-label={"Filter by #{@related_filter_label}"}
                     >
-                      <button
+                      <.button
                         type="button"
+                        variant={if is_nil(@selected_related_genus), do: "primary", else: "secondary"}
+                        size="sm"
                         phx-click="filter_related_genus"
                         phx-value-id="all"
                         aria-pressed={is_nil(@selected_related_genus)}
-                        class={[
-                          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-                          is_nil(@selected_related_genus) &&
-                            "border-gf-maroon bg-gf-maroon text-white",
-                          !is_nil(@selected_related_genus) &&
-                            "border-gray-300 bg-white text-gray-700 hover:border-gf-maroon"
-                        ]}
+                        class="gap-2 rounded-full"
                       >
                         All species <span class="text-xs opacity-80">{@total_species_count}</span>
-                      </button>
-                      <button
+                      </.button>
+                      <.button
                         :for={genus <- @related_genera}
                         type="button"
+                        variant={
+                          if @selected_related_genus == genus.id,
+                            do: "primary",
+                            else: "secondary"
+                        }
+                        size="sm"
                         phx-click="filter_related_genus"
                         phx-value-id={genus.id}
                         aria-pressed={@selected_related_genus == genus.id}
                         title={"#{genus.association_count} species-to-species associations"}
-                        class={[
-                          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-                          @selected_related_genus == genus.id &&
-                            "border-gf-maroon bg-gf-maroon text-white",
-                          @selected_related_genus != genus.id &&
-                            "border-gray-300 bg-white text-gray-700 hover:border-gf-maroon hover:bg-gf-cream"
-                        ]}
+                        class="gap-2 rounded-full hover:border-gf-maroon"
                       >
                         <.taxon_name name={genus.name} rank="genus" />
                         <span class={[
@@ -443,7 +442,7 @@ defmodule GallformersWeb.GenusLive do
                         ]}>
                           {genus.focal_species_count}
                         </span>
-                      </button>
+                      </.button>
                     </div>
                     <p :if={@selected_related_genus} class="mt-4 text-sm text-gray-600">
                       Showing species associated with
@@ -451,14 +450,16 @@ defmodule GallformersWeb.GenusLive do
                         name={Enum.find(@related_genera, &(&1.id == @selected_related_genus)).name}
                         rank="genus"
                       />.
-                      <button
+                      <.button
                         type="button"
+                        variant="ghost"
+                        size="sm"
                         phx-click="filter_related_genus"
                         phx-value-id="all"
-                        class="ml-1 text-gf-maroon underline hover:no-underline"
+                        class="ml-1 px-1 underline hover:no-underline"
                       >
                         Clear filter
-                      </button>
+                      </.button>
                     </p>
                   </.card>
                 </div>

--- a/lib/gallformers_web/live/genus_live.ex
+++ b/lib/gallformers_web/live/genus_live.ex
@@ -138,6 +138,9 @@ defmodule GallformersWeb.GenusLive do
           "Count"
       end
 
+    {related_genera, related_heading, related_filter_label} =
+      related_genus_assigns(genus_id, species)
+
     assign(socket,
       page_title: "Genus #{lineage.genus.name}",
       page_description:
@@ -150,6 +153,11 @@ defmodule GallformersWeb.GenusLive do
       disambiguation: nil,
       species: species,
       search_query: "",
+      show_related_genera: false,
+      selected_related_genus: nil,
+      related_genera: related_genera,
+      related_heading: related_heading,
+      related_filter_label: related_filter_label,
       sort_by: :name,
       sort_dir: :asc,
       filtered_species: species,
@@ -158,6 +166,20 @@ defmodule GallformersWeb.GenusLive do
       error: nil
     )
   end
+
+  defp related_genus_assigns(_genus_id, []), do: {[], nil, nil}
+
+  defp related_genus_assigns(genus_id, [%{taxoncode: "gall"} | _]) do
+    related_genera = Taxonomy.list_associated_genera(genus_id, "gall")
+    {related_genera, "Host genera used by this genus", "host genus"}
+  end
+
+  defp related_genus_assigns(genus_id, [%{taxoncode: "plant"} | _]) do
+    related_genera = Taxonomy.list_associated_genera(genus_id, "plant")
+    {related_genera, "Gall-former genera found on this host", "gall-former genus"}
+  end
+
+  defp related_genus_assigns(_genus_id, _species), do: {[], nil, nil}
 
   defp format_with_description(name, description) do
     if description && String.trim(description) != "" do
@@ -173,6 +195,22 @@ defmodule GallformersWeb.GenusLive do
      socket
      |> assign(:search_query, query)
      |> filter_species()}
+  end
+
+  @impl true
+  def handle_event("filter_related_genus", %{"id" => id}, socket) do
+    selected_id = if id == "all", do: nil, else: String.to_integer(id)
+
+    {:noreply,
+     socket
+     |> assign(:show_related_genera, true)
+     |> assign(:selected_related_genus, selected_id)
+     |> filter_species()}
+  end
+
+  @impl true
+  def handle_event("toggle_related_genera", _params, socket) do
+    {:noreply, update(socket, :show_related_genera, &(!&1))}
   end
 
   @impl true
@@ -195,16 +233,36 @@ defmodule GallformersWeb.GenusLive do
     query = String.downcase(socket.assigns.search_query)
 
     filtered =
-      if query == "" do
-        socket.assigns.species
-      else
-        Enum.filter(socket.assigns.species, fn s ->
-          String.contains?(String.downcase(s.name), query) ||
-            (s.common_name && String.contains?(String.downcase(s.common_name), query))
-        end)
-      end
+      socket.assigns.species
+      |> filter_by_related_genus(
+        socket.assigns.selected_related_genus,
+        socket.assigns.related_genera
+      )
+      |> filter_by_search(query)
 
     assign(socket, :filtered_species, filtered)
+  end
+
+  defp filter_by_search(species, ""), do: species
+
+  defp filter_by_search(species, query) do
+    Enum.filter(species, fn species ->
+      String.contains?(String.downcase(species.name), query) ||
+        (species.common_name &&
+           String.contains?(String.downcase(species.common_name), query))
+    end)
+  end
+
+  defp filter_by_related_genus(species, nil, _related_genera), do: species
+
+  defp filter_by_related_genus(species, selected_id, related_genera) do
+    allowed_ids =
+      related_genera
+      |> Enum.find(%{focal_species_ids: []}, &(&1.id == selected_id))
+      |> Map.fetch!(:focal_species_ids)
+      |> MapSet.new()
+
+    Enum.filter(species, &MapSet.member?(allowed_ids, &1.id))
   end
 
   defp sorted_species(species, sort_by, sort_dir) do
@@ -292,6 +350,119 @@ defmodule GallformersWeb.GenusLive do
             <%!-- Species list --%>
             <div class="mt-6">
               <%= if @total_species_count > 0 do %>
+                <div :if={@related_genera != []} class="mb-6">
+                  <button
+                    :if={!@show_related_genera}
+                    type="button"
+                    phx-click="toggle_related_genera"
+                    aria-expanded="false"
+                    aria-controls="related-genera-filters"
+                    class="w-full flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white px-4 py-3 text-left text-gf-maroon shadow-sm hover:border-gf-maroon hover:bg-gf-cream transition-colors"
+                  >
+                    <span class="flex min-w-0 items-center gap-2">
+                      <.icon name="ph-arrows-left-right" class="size-5 shrink-0" />
+                      <span class="font-medium">{@related_heading}</span>
+                      <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                        {length(@related_genera)}
+                      </span>
+                      <span :if={@selected_related_genus} class="truncate text-sm text-gray-600">
+                        — filtered by
+                        <.taxon_name
+                          name={Enum.find(@related_genera, &(&1.id == @selected_related_genus)).name}
+                          rank="genus"
+                        />
+                      </span>
+                    </span>
+                    <span class="flex shrink-0 items-center gap-1 text-sm">
+                      Show filters <.icon name="ph-caret-down" class="size-4" />
+                    </span>
+                  </button>
+
+                  <.card
+                    :if={@show_related_genera}
+                    title={"#{@related_heading} (#{length(@related_genera)})"}
+                    icon="ph-arrows-left-right"
+                    id="related-genera-filters"
+                  >
+                    <:actions>
+                      <button
+                        type="button"
+                        phx-click="toggle_related_genera"
+                        aria-expanded="true"
+                        aria-controls="related-genera-filters"
+                        class="inline-flex items-center gap-1 text-sm text-gf-maroon hover:underline"
+                      >
+                        Hide <.icon name="ph-caret-up" class="size-4" />
+                      </button>
+                    </:actions>
+                    <p class="text-sm text-gray-600 mb-4">
+                      Select a genus to filter the species list below. Counts show how many species
+                      in <.taxon_name name={@lineage.genus.name} rank="genus" />
+                      have that association.
+                    </p>
+                    <div
+                      class="flex flex-wrap gap-2"
+                      role="group"
+                      aria-label={"Filter by #{@related_filter_label}"}
+                    >
+                      <button
+                        type="button"
+                        phx-click="filter_related_genus"
+                        phx-value-id="all"
+                        aria-pressed={is_nil(@selected_related_genus)}
+                        class={[
+                          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                          is_nil(@selected_related_genus) &&
+                            "border-gf-maroon bg-gf-maroon text-white",
+                          !is_nil(@selected_related_genus) &&
+                            "border-gray-300 bg-white text-gray-700 hover:border-gf-maroon"
+                        ]}
+                      >
+                        All species <span class="text-xs opacity-80">{@total_species_count}</span>
+                      </button>
+                      <button
+                        :for={genus <- @related_genera}
+                        type="button"
+                        phx-click="filter_related_genus"
+                        phx-value-id={genus.id}
+                        aria-pressed={@selected_related_genus == genus.id}
+                        title={"#{genus.association_count} species-to-species associations"}
+                        class={[
+                          "inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                          @selected_related_genus == genus.id &&
+                            "border-gf-maroon bg-gf-maroon text-white",
+                          @selected_related_genus != genus.id &&
+                            "border-gray-300 bg-white text-gray-700 hover:border-gf-maroon hover:bg-gf-cream"
+                        ]}
+                      >
+                        <.taxon_name name={genus.name} rank="genus" />
+                        <span class={[
+                          "rounded-full px-1.5 py-0.5 text-xs",
+                          @selected_related_genus == genus.id && "bg-white/20",
+                          @selected_related_genus != genus.id && "bg-gray-100 text-gray-600"
+                        ]}>
+                          {genus.focal_species_count}
+                        </span>
+                      </button>
+                    </div>
+                    <p :if={@selected_related_genus} class="mt-4 text-sm text-gray-600">
+                      Showing species associated with
+                      <.taxon_name
+                        name={Enum.find(@related_genera, &(&1.id == @selected_related_genus)).name}
+                        rank="genus"
+                      />.
+                      <button
+                        type="button"
+                        phx-click="filter_related_genus"
+                        phx-value-id="all"
+                        class="ml-1 text-gf-maroon underline hover:no-underline"
+                      >
+                        Clear filter
+                      </button>
+                    </p>
+                  </.card>
+                </div>
+
                 <h2 class="text-lg font-semibold text-gray-800 mb-3">
                   Species ({@total_species_count})
                 </h2>

--- a/test/gallformers/taxonomy_test.exs
+++ b/test/gallformers/taxonomy_test.exs
@@ -4,7 +4,7 @@ defmodule Gallformers.TaxonomyTest do
   """
   use Gallformers.DataCase, async: true
 
-  alias Gallformers.Repo
+  alias Gallformers.{Galls, Repo}
   alias Gallformers.Species.Alias
   alias Gallformers.Species.Species
   alias Gallformers.Taxonomy
@@ -2930,5 +2930,103 @@ defmodule Gallformers.TaxonomyTest do
 
       assert section.id in section_ids
     end
+  end
+
+  describe "list_associated_genera/2" do
+    test "lists host genera associated with species in a gall genus" do
+      fixture = create_associated_genera_fixture()
+      host_genus_id = fixture.host_genus.id
+      host_genus_name = fixture.host_genus.name
+
+      assert [
+               %{
+                 id: ^host_genus_id,
+                 name: ^host_genus_name,
+                 focal_species_count: 2,
+                 association_count: 3,
+                 focal_species_ids: gall_ids
+               }
+             ] = Taxonomy.list_associated_genera(fixture.gall_genus.id, "gall")
+
+      assert gall_ids == Enum.sort([fixture.gall_one.id, fixture.gall_two.id])
+    end
+
+    test "lists gall genera associated with species in a host genus" do
+      fixture = create_associated_genera_fixture()
+      gall_genus_id = fixture.gall_genus.id
+      gall_genus_name = fixture.gall_genus.name
+
+      assert [
+               %{
+                 id: ^gall_genus_id,
+                 name: ^gall_genus_name,
+                 focal_species_count: 2,
+                 association_count: 3,
+                 focal_species_ids: host_ids
+               }
+             ] = Taxonomy.list_associated_genera(fixture.host_genus.id, "plant")
+
+      assert host_ids == Enum.sort([fixture.host_one.id, fixture.host_two.id])
+    end
+  end
+
+  defp create_associated_genera_fixture do
+    {:ok, gall_family} =
+      Taxonomy.create_taxonomy(%{
+        name: "AssociatedGallFamily",
+        description: "Wasp",
+        type: "family"
+      })
+
+    {:ok, host_family} =
+      Taxonomy.create_taxonomy(%{
+        name: "AssociatedHostFamily",
+        description: "Plant",
+        type: "family"
+      })
+
+    {:ok, gall_genus} =
+      Taxonomy.create_taxonomy(%{
+        name: "AssociatedGallGenus",
+        type: "genus",
+        parent_id: gall_family.id
+      })
+
+    {:ok, host_genus} =
+      Taxonomy.create_taxonomy(%{
+        name: "AssociatedHostGenus",
+        type: "genus",
+        parent_id: host_family.id
+      })
+
+    gall_one = Repo.insert!(%Species{name: "AssociatedGallGenus one", taxoncode: "gall"})
+    gall_two = Repo.insert!(%Species{name: "AssociatedGallGenus two", taxoncode: "gall"})
+    host_one = Repo.insert!(%Species{name: "AssociatedHostGenus one", taxoncode: "plant"})
+    host_two = Repo.insert!(%Species{name: "AssociatedHostGenus two", taxoncode: "plant"})
+
+    for species <- [gall_one, gall_two] do
+      {:ok, _} = Taxonomy.link_species_to_taxonomy(species.id, gall_genus.id)
+    end
+
+    for species <- [host_one, host_two] do
+      {:ok, _} = Taxonomy.link_species_to_taxonomy(species.id, host_genus.id)
+    end
+
+    for {gall, host} <- [{gall_one, host_one}, {gall_one, host_two}, {gall_two, host_one}] do
+      {:ok, _} =
+        Galls.create_gall_host(%{
+          gall_species_id: gall.id,
+          host_species_id: host.id
+        })
+    end
+
+    %{
+      gall_genus: gall_genus,
+      host_genus: host_genus,
+      gall_one: gall_one,
+      gall_two: gall_two,
+      host_one: host_one,
+      host_two: host_two
+    }
   end
 end

--- a/test/gallformers_web/live/genus_live_test.exs
+++ b/test/gallformers_web/live/genus_live_test.exs
@@ -47,18 +47,9 @@ defmodule GallformersWeb.GenusLiveTest do
     end
 
     test "shows associated host genera collapsed and filters species when expanded", %{conn: conn} do
-      host_genus = create_host_mapping()
+      fixture = create_mapping_fixture()
 
-      unrelated_gall =
-        Repo.insert!(%Species{
-          name: "Andricus testunrelated",
-          taxoncode: "gall",
-          abundance_id: 1
-        })
-
-      {:ok, _} = Taxonomy.link_species_to_taxonomy(unrelated_gall.id, 33)
-
-      {:ok, view, html} = live(conn, "/genus/Andricus")
+      {:ok, view, html} = live(conn, "/genus/#{fixture.gall_genus.name}")
 
       assert html =~ "Host genera used by this genus"
       assert html =~ "Show filters"
@@ -69,49 +60,109 @@ defmodule GallformersWeb.GenusLiveTest do
       |> render_click()
 
       assert has_element?(view, "#related-genera-filters")
-      assert render(view) =~ "TestHostGenus"
+      assert render(view) =~ fixture.host_genus.name
 
       view
-      |> element("button[phx-click='filter_related_genus'][phx-value-id='#{host_genus.id}']")
+      |> element(
+        "button[phx-click='filter_related_genus'][phx-value-id='#{fixture.host_genus.id}']"
+      )
       |> render_click()
 
       filtered_html = render(view)
-      assert filtered_html =~ "Andricus crystallinus"
-      refute filtered_html =~ "Andricus testunrelated"
+      assert filtered_html =~ fixture.associated_gall.name
+      refute filtered_html =~ fixture.unrelated_gall.name
     end
 
-    test "lists gall genera associated with a host genus" do
-      host_genus = create_host_mapping()
+    test "shows associated gall genera collapsed and filters hosts when expanded", %{conn: conn} do
+      fixture = create_mapping_fixture()
 
-      assert [
-               %{
-                 id: 33,
-                 name: "Andricus",
-                 focal_species_count: 1,
-                 focal_species_ids: [1]
-               }
-             ] = Taxonomy.list_associated_genera(host_genus.id, "plant")
+      {:ok, view, html} = live(conn, "/genus/#{fixture.host_genus.name}")
+
+      assert html =~ "Gall-former genera found on this host"
+      assert html =~ "Show filters"
+      refute has_element?(view, "#related-genera-filters")
+
+      view
+      |> element("button[phx-click='toggle_related_genera']")
+      |> render_click()
+
+      assert has_element?(view, "#related-genera-filters")
+      assert render(view) =~ fixture.gall_genus.name
+
+      view
+      |> element(
+        "button[phx-click='filter_related_genus'][phx-value-id='#{fixture.gall_genus.id}']"
+      )
+      |> render_click()
+
+      filtered_html = render(view)
+      assert filtered_html =~ fixture.associated_host.name
+      refute filtered_html =~ fixture.unrelated_host.name
     end
   end
 
-  defp create_host_mapping do
-    {:ok, family} =
+  defp create_mapping_fixture do
+    {:ok, gall_family} =
       Taxonomy.create_taxonomy(%{
-        name: "TestHostFamily",
+        name: "LiveMappingGallFamily",
+        description: "Wasp",
+        type: "family"
+      })
+
+    {:ok, host_family} =
+      Taxonomy.create_taxonomy(%{
+        name: "LiveMappingHostFamily",
         description: "Plant",
         type: "family"
       })
 
-    {:ok, host_genus} =
+    {:ok, gall_genus} =
       Taxonomy.create_taxonomy(%{
-        name: "TestHostGenus",
+        name: "LiveMappingGallGenus",
         type: "genus",
-        parent_id: family.id
+        parent_id: gall_family.id
       })
 
-    {:ok, _} = Taxonomy.link_species_to_taxonomy(1, host_genus.id)
-    {:ok, _} = Galls.create_gall_host(%{gall_species_id: 200, host_species_id: 1})
+    {:ok, host_genus} =
+      Taxonomy.create_taxonomy(%{
+        name: "LiveMappingHostGenus",
+        type: "genus",
+        parent_id: host_family.id
+      })
 
-    host_genus
+    associated_gall =
+      Repo.insert!(%Species{name: "LiveMappingGallGenus associated", taxoncode: "gall"})
+
+    unrelated_gall =
+      Repo.insert!(%Species{name: "LiveMappingGallGenus unrelated", taxoncode: "gall"})
+
+    associated_host =
+      Repo.insert!(%Species{name: "LiveMappingHostGenus associated", taxoncode: "plant"})
+
+    unrelated_host =
+      Repo.insert!(%Species{name: "LiveMappingHostGenus unrelated", taxoncode: "plant"})
+
+    for species <- [associated_gall, unrelated_gall] do
+      {:ok, _} = Taxonomy.link_species_to_taxonomy(species.id, gall_genus.id)
+    end
+
+    for species <- [associated_host, unrelated_host] do
+      {:ok, _} = Taxonomy.link_species_to_taxonomy(species.id, host_genus.id)
+    end
+
+    {:ok, _} =
+      Galls.create_gall_host(%{
+        gall_species_id: associated_gall.id,
+        host_species_id: associated_host.id
+      })
+
+    %{
+      gall_genus: gall_genus,
+      host_genus: host_genus,
+      associated_gall: associated_gall,
+      unrelated_gall: unrelated_gall,
+      associated_host: associated_host,
+      unrelated_host: unrelated_host
+    }
   end
 end

--- a/test/gallformers_web/live/genus_live_test.exs
+++ b/test/gallformers_web/live/genus_live_test.exs
@@ -61,6 +61,7 @@ defmodule GallformersWeb.GenusLiveTest do
 
       assert has_element?(view, "#related-genera-filters")
       assert render(view) =~ fixture.host_genus.name
+      assert has_element?(view, "button.gf-btn-pill[phx-value-id='all']")
 
       view
       |> element(
@@ -88,6 +89,7 @@ defmodule GallformersWeb.GenusLiveTest do
 
       assert has_element?(view, "#related-genera-filters")
       assert render(view) =~ fixture.gall_genus.name
+      assert has_element?(view, "button.gf-btn-pill[phx-value-id='all']")
 
       view
       |> element(

--- a/test/gallformers_web/live/genus_live_test.exs
+++ b/test/gallformers_web/live/genus_live_test.exs
@@ -5,6 +5,9 @@ defmodule GallformersWeb.GenusLiveTest do
   use GallformersWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
+  alias Gallformers.{Galls, Repo, Taxonomy}
+  alias Gallformers.Species.Species
+
   describe "GenusLive with name-based URLs" do
     test "renders genus page by name", %{conn: conn} do
       # Andricus (id=33) is a genus under Cynipini tribe
@@ -42,5 +45,73 @@ defmodule GallformersWeb.GenusLiveTest do
 
       assert html =~ "not found" or html =~ "Not Found"
     end
+
+    test "shows associated host genera collapsed and filters species when expanded", %{conn: conn} do
+      host_genus = create_host_mapping()
+
+      unrelated_gall =
+        Repo.insert!(%Species{
+          name: "Andricus testunrelated",
+          taxoncode: "gall",
+          abundance_id: 1
+        })
+
+      {:ok, _} = Taxonomy.link_species_to_taxonomy(unrelated_gall.id, 33)
+
+      {:ok, view, html} = live(conn, "/genus/Andricus")
+
+      assert html =~ "Host genera used by this genus"
+      assert html =~ "Show filters"
+      refute has_element?(view, "#related-genera-filters")
+
+      view
+      |> element("button[phx-click='toggle_related_genera']")
+      |> render_click()
+
+      assert has_element?(view, "#related-genera-filters")
+      assert render(view) =~ "TestHostGenus"
+
+      view
+      |> element("button[phx-click='filter_related_genus'][phx-value-id='#{host_genus.id}']")
+      |> render_click()
+
+      filtered_html = render(view)
+      assert filtered_html =~ "Andricus crystallinus"
+      refute filtered_html =~ "Andricus testunrelated"
+    end
+
+    test "lists gall genera associated with a host genus" do
+      host_genus = create_host_mapping()
+
+      assert [
+               %{
+                 id: 33,
+                 name: "Andricus",
+                 focal_species_count: 1,
+                 focal_species_ids: [1]
+               }
+             ] = Taxonomy.list_associated_genera(host_genus.id, "plant")
+    end
+  end
+
+  defp create_host_mapping do
+    {:ok, family} =
+      Taxonomy.create_taxonomy(%{
+        name: "TestHostFamily",
+        description: "Plant",
+        type: "family"
+      })
+
+    {:ok, host_genus} =
+      Taxonomy.create_taxonomy(%{
+        name: "TestHostGenus",
+        type: "genus",
+        parent_id: family.id
+      })
+
+    {:ok, _} = Taxonomy.link_species_to_taxonomy(1, host_genus.id)
+    {:ok, _} = Galls.create_gall_host(%{gall_species_id: 200, host_species_id: 1})
+
+    host_genus
   end
 end


### PR DESCRIPTION
## Summary
- show host genera on gall-former genus pages and gall-former genera on host genus pages
- keep the mapping collapsed by default, with genus and association counts in an expandable filter panel
- filter the species table by a selected related genus while preserving text search
- cover both mapping directions and the collapsed/filter interaction

## Verification
- `mix precommit` (2,146 tests, 0 failures)
- manually verified `/genus/Andricus` and `/genus/Quercus` against local production data

Closes #575